### PR TITLE
feat: Security Spec

### DIFF
--- a/spec/auth.md
+++ b/spec/auth.md
@@ -2,16 +2,16 @@
 
 ## Relay <--> Echo Server
 
-We use Ed25519 to verify that requests from the Relay network are valid and intended for the Echo Server Instance that has received them.
+We use Ed25519 to verify that requests from the Relay are valid and intended for the Echo Server Instance that has received them.
 
 ### Implementation
 
 Echo Server generates<sup>[[1]](#generating-keys)</sup> an Ed25519 key-pair and stores that in-memory - or in files specified using environment variables. The generated
-public key is then sent to the Relay network along with a cloud app project id and the public url (both from environment variables) so that
-future requests to the relay can be signed and validated. The Echo Server instance also fetches the Relay network's public key and caches it
+public key is then sent to the Relay along with a cloud app project id and the public url (both from environment variables) so that
+future requests to the relay can be signed and validated. The Echo Server instance also fetches the Relay's public key and caches it
 so that requests received can be validated.
 
-On start-up Echo Server sends [the register request](#post-pushservers) to the relay network<sup>[[2]](#registering-with-relay)</sup>. This request is formatted using the
+On start-up Echo Server sends [the register request](#post-pushservers) to the relay<sup>[[2]](#registering-with-relay)</sup>. This request is formatted using the
 public key from the above key-pair as well as the provided `projectId` and `publicUrl` (both provided via Environment Variables).
 
 ### Relay Endpoints
@@ -19,7 +19,7 @@ public key from the above key-pair as well as the provided `projectId` and `publ
 #### GET `/public-key`
 ##### Response
 > **Note**
-> This is an example Ed25519 Public Key, this is not a valid Public Key for the Relay Network.
+> This is an example Ed25519 Public Key, this is not a valid Public Key for the Relay.
 ```
 693a98827a9c7e8f818af53b9720671eb4d3075815a8c2c8f6d0da12ba1aba7a
 ```

--- a/spec/auth.md
+++ b/spec/auth.md
@@ -12,7 +12,7 @@ future requests to the relay can be signed and validated. The Echo Server instan
 so that requests received can be validated.
 
 On start-up Echo Server sends [the register request](#post-pushservers) to the relay network<sup>[[2]](#registering-with-relay)</sup>. This request is formatted using the
-public key from the above key-pair as well as the provided `project_id` and `public_url` (both provided via Environment Variables).
+public key from the above key-pair as well as the provided `projectId` and `publicUrl` (both provided via Environment Variables).
 
 ### Relay Endpoints
 
@@ -27,13 +27,13 @@ public key from the above key-pair as well as the provided `project_id` and `pub
 #### POST `/push/servers`
 ##### Request
 > **Note**
-> This is an example request. The `project_id`, `public_key` & `public_url` values are not valid.
+> This is an example request. The `projectId`, `publicKey` & `publicUrl` values are not valid.
 ```json
 {
-    "project_id": "83f11e753439fab08222b45e2d029eab",
-    "public_key": "d5aa4b55ecf4553c3ef8f8a945d9449394f0b3b7787af049d1d4828037465a4f",
-    "public_url": "https://push.walletconnect.com",
-    "echo_server": {
+    "projectId": "83f11e753439fab08222b45e2d029eab",
+    "publicKey": "d5aa4b55ecf4553c3ef8f8a945d9449394f0b3b7787af049d1d4828037465a4f",
+    "publicUrl": "https://push.walletconnect.com",
+    "echoServer": {
       "version": "0.1.0",
       "git": "d0be36e9007ef73e0dafb8d2d9f3172c4d9f8333"
     }

--- a/spec/auth.md
+++ b/spec/auth.md
@@ -1,0 +1,46 @@
+# Echo Server Authentication
+
+## Relay <--> Echo Server
+
+We use Ed25519 to verify that requests from the Relay network are valid and intended for the Echo Server Instance that has received them.
+
+### Implementation
+
+Echo Server generates an Ed25519 key-pair and stores that in-memory - or in files specified using environment variables. The generated
+public key is then sent to the Relay network along with a cloud app project id and the public url (both from environment variables) so that
+future requests to the relay can be signed and validated. The Echo Server instance also fetches the Relay network's public key and caches it
+so that requests received can be validated.
+
+### Relay Endpoints
+
+#### GET `/public-key`
+##### Response
+> **Note**
+> This is an example Ed25519 Public Key, this is not a valid Public Key for the Relay Network.
+```
+693a98827a9c7e8f818af53b9720671eb4d3075815a8c2c8f6d0da12ba1aba7a
+```
+
+#### POST `/push/servers`
+##### Request
+> **Note**
+> This is an example request. The `project_id` & `public_key` values are not valid.
+```json
+{
+    "project_id": "83f11e753439fab08222b45e2d029eab",
+    "public_key": "d5aa4b55ecf4553c3ef8f8a945d9449394f0b3b7787af049d1d4828037465a4f",
+    "echo_server": {
+      "version": "0.1.0",
+      "git": "d0be36e9007ef73e0dafb8d2d9f3172c4d9f8333"
+    }
+}
+```
+##### Response
+
+> **Note**
+> Responses haven't been confirmed yet.
+
+```json
+{
+}
+```

--- a/spec/auth.md
+++ b/spec/auth.md
@@ -24,11 +24,12 @@ so that requests received can be validated.
 #### POST `/push/servers`
 ##### Request
 > **Note**
-> This is an example request. The `project_id` & `public_key` values are not valid.
+> This is an example request. The `project_id`, `public_key` & `public_url` values are not valid.
 ```json
 {
     "project_id": "83f11e753439fab08222b45e2d029eab",
     "public_key": "d5aa4b55ecf4553c3ef8f8a945d9449394f0b3b7787af049d1d4828037465a4f",
+    "public_url": "https://push.walletconnect.com",
     "echo_server": {
       "version": "0.1.0",
       "git": "d0be36e9007ef73e0dafb8d2d9f3172c4d9f8333"

--- a/spec/auth.md
+++ b/spec/auth.md
@@ -6,10 +6,13 @@ We use Ed25519 to verify that requests from the Relay network are valid and inte
 
 ### Implementation
 
-Echo Server generates an Ed25519 key-pair and stores that in-memory - or in files specified using environment variables. The generated
+Echo Server generates<sup>[[1]](#generating-keys)</sup> an Ed25519 key-pair and stores that in-memory - or in files specified using environment variables. The generated
 public key is then sent to the Relay network along with a cloud app project id and the public url (both from environment variables) so that
 future requests to the relay can be signed and validated. The Echo Server instance also fetches the Relay network's public key and caches it
 so that requests received can be validated.
+
+On start-up Echo Server sends [the register request](#post-pushservers) to the relay network<sup>[[2]](#registering-with-relay)</sup>. This request is formatted using the
+public key from the above key-pair as well as the provided `project_id` and `public_url` (both provided via Environment Variables).
 
 ### Relay Endpoints
 
@@ -45,3 +48,12 @@ so that requests received can be validated.
 {
 }
 ```
+
+### Notes
+#### Generating Keys
+If an environment variable is provided to a path that exists Echo Server will treat that as the private key that it should use and
+as such will not generate a key. It will instead read the provided file and attempt to parse that as an Ed25519 private key.
+
+#### Registering with Relay
+In this implementation the public key, is sent everytime a node starts up. This ensures that the relay always has up-to date
+information for the Echo Server instance. If you have multiple Echo Server instances ensure that all the private keys are the same.

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -2,6 +2,9 @@
 
 This is an overview spec document which details the endpoint and what they expect to receive and in turn what responses you can expect.
 
+## Security
+The details of Echo Server's Security are in [auth.md](./auth.md)
+
 ## Responses
 These are the default responses and are only different if otherwise specified.
 


### PR DESCRIPTION
# Description
This PR adds the security spec for communication between the Relay and Echo Server instances. This allow's both the Relay and Echo Server to validate requests they have received.

There will potentially be a future change to the spec for Client --> Echo Server auth but that is not included in this PR.

## Due Diligence

* [x] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update