### PR TITLE
feat: move clippy config to config file and stop using in CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.'cfg(feature = "cargo-clippy")']
+rustflags = [
+  "-Dclippy::all",
+#   "-Dclippy::await_holding_lock"
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
         cargo:
           - name: "Clippy"
             cmd: clippy
-            args: -- -D clippy::all
             cache: {}
           - name: "Formatting"
             cmd: fmt


### PR DESCRIPTION
# Description

move clippy checks to config file and stop using in CI.

Resolves #9 

## How Has This Been Tested?

Run `cargo clippy` in your local machine and see result.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update

# Suggestion
I think we should still make use of clippy check in CI by add more arguments `-- -D warnings`, this is more strictly. It will notify us for each PR is created. Warnings are fine. It won't be required to pass CI, but it would be great if they are eventually resolved one way or the other. So,why don't we keep this check in CI?