### PR TITLE
fix: `database_url` is optional in env

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -23,7 +23,6 @@ pub struct Config {
     pub port: u16,
     #[serde(default = "default_log_level")]
     pub log_level: String,
-    #[serde(default = "default_database_url")]
     pub database_url: String,
     pub telemetry_enabled: Option<bool>,
     pub telemetry_grpc_url: Option<String>,
@@ -63,10 +62,6 @@ fn default_port() -> u16 {
 
 fn default_log_level() -> String {
     "WARN".to_string()
-}
-
-fn default_database_url() -> String {
-    "".to_string()
 }
 
 pub fn get_config() -> error::Result<Config> {

--- a/src/env.rs
+++ b/src/env.rs
@@ -23,7 +23,7 @@ pub struct Config {
     pub port: u16,
     #[serde(default = "default_log_level")]
     pub log_level: String,
-    pub database_url: Option<String>,
+    pub database_url: String,
     pub telemetry_enabled: Option<bool>,
     pub telemetry_grpc_url: Option<String>,
     pub apns_certificate: Option<ApnsCertificateConfig>,
@@ -34,6 +34,10 @@ pub struct Config {
 impl Config {
     pub fn log_level(&self) -> tracing::Level {
         tracing::Level::from_str(self.log_level.as_str()).expect("Invalid log level")
+    }
+
+    pub fn database_url(&self) -> &str {
+        self.database_url.as_str()
     }
 
     pub fn supported_providers(&self) -> Vec<ProviderKind> {

--- a/src/env.rs
+++ b/src/env.rs
@@ -23,6 +23,7 @@ pub struct Config {
     pub port: u16,
     #[serde(default = "default_log_level")]
     pub log_level: String,
+    #[serde(default = "default_database_url")]
     pub database_url: String,
     pub telemetry_enabled: Option<bool>,
     pub telemetry_grpc_url: Option<String>,
@@ -34,10 +35,6 @@ pub struct Config {
 impl Config {
     pub fn log_level(&self) -> tracing::Level {
         tracing::Level::from_str(self.log_level.as_str()).expect("Invalid log level")
-    }
-
-    pub fn database_url(&self) -> &str {
-        self.database_url.as_str()
     }
 
     pub fn supported_providers(&self) -> Vec<ProviderKind> {
@@ -66,6 +63,10 @@ fn default_port() -> u16 {
 
 fn default_log_level() -> String {
     "WARN".to_string()
+}
+
+fn default_database_url() -> String {
+    "".to_string()
 }
 
 pub fn get_config() -> error::Result<Config> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ async fn main() -> error::Result<()> {
 
     let store = PgPoolOptions::new()
         .max_connections(5)
-        .connect(config.database_url())
+        .connect(&config.database_url)
         .await?;
 
     // Run database migrations. `./migrations` is the path to migrations, relative to the root dir (the directory

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,14 +39,9 @@ async fn main() -> error::Result<()> {
         panic!("You must enable at least one provider.");
     }
 
-    let database_url = config
-        .database_url
-        .as_deref()
-        .expect("database url is missing");
-
     let store = PgPoolOptions::new()
         .max_connections(5)
-        .connect(database_url)
+        .connect(config.database_url())
         .await?;
 
     // Run database migrations. `./migrations` is the path to migrations, relative to the root dir (the directory

--- a/tests/env/mod.rs
+++ b/tests/env/mod.rs
@@ -3,6 +3,7 @@ use serial_test::serial;
 use std::env;
 
 pub fn reset_env() {
+    env::remove_var("DATABASE_URL");
     env::remove_var("PORT");
     env::remove_var("LOG_LEVEL");
     env::remove_var("TELEMETRY_ENABLED");
@@ -15,6 +16,7 @@ pub fn reset_env() {
 fn default_config() {
     reset_env();
 
+    env::set_var("DATABASE_URL", "");
     let config = get_config().expect("Failed to fetch config");
 
     assert_eq!(
@@ -37,6 +39,7 @@ fn default_config() {
 fn env_config_1() {
     reset_env();
 
+    env::set_var("DATABASE_URL", "");
     env::set_var("TELEMETRY_ENABLED", "false");
 
     let config = get_config().expect("Failed to fetch config");
@@ -61,6 +64,7 @@ fn env_config_1() {
 fn env_config_2() {
     reset_env();
 
+    env::set_var("DATABASE_URL", "");
     env::set_var("PORT", "3001");
     env::set_var("LOG_LEVEL", "TRACE");
 
@@ -86,6 +90,7 @@ fn env_config_2() {
 fn env_config_3() {
     reset_env();
 
+    env::set_var("DATABASE_URL", "");
     env::set_var("PORT", "8080");
     env::set_var("LOG_LEVEL", "ERROR");
 
@@ -111,6 +116,7 @@ fn env_config_3() {
 fn env_config_4() {
     reset_env();
 
+    env::set_var("DATABASE_URL", "");
     env::set_var("PORT", "3001");
     env::set_var("LOG_LEVEL", "TRACE");
     env::set_var("TELEMETRY_ENABLED", "true");

--- a/tests/providers/fcm.rs
+++ b/tests/providers/fcm.rs
@@ -15,6 +15,7 @@ fn fetch_provider() {
     // Reset the env vars
     crate::env::reset_env();
 
+    env::set_var("DATABASE_URL", "");
     env::set_var("FCM_API_KEY", FCM_API_KEY);
 
     let config = get_config().expect("Failed to get config");

--- a/tests/providers/noop.rs
+++ b/tests/providers/noop.rs
@@ -3,6 +3,7 @@ use echo_server::providers::noop::NoopProvider;
 use echo_server::providers::{get_provider, Provider};
 use echo_server::state::new_state;
 use echo_server::{env::get_config, providers::ProviderKind};
+use std::env;
 use std::sync::Arc;
 
 // const PUSH_TOKEN: &str = "0000-0000-0000-0000";
@@ -10,6 +11,10 @@ use std::sync::Arc;
 
 #[test]
 fn fetch_provider() {
+    // Reset the env vars
+    crate::env::reset_env();
+
+    env::set_var("DATABASE_URL", "");
     let config = get_config().expect("Failed to get config");
     let store = MockStore::new();
     let state = new_state(config, store).expect("Failed to create state");


### PR DESCRIPTION
# Description

make `database_url` is required in env.

Resolves #18 

## How Has This Been Tested?


## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update