### PR TITLE
fix: APNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ Push server for the WalletConnect v2 Protocol
 
 > **Note** This is only available for WalletConnect v2 and is a breaking change from the Push supported in v1.
 
+## Notification Providers
+This list contains both supported and potentially planned providers
+- [x] FCM (API Key)
+- [ ] FCM (Google Services)
+- [x] APNS (Certificate Based)
+- [ ] APNS (Token Based)
+- [ ] Web Push
+
 ## Supporting Notifications
 > **Note** Full documentation will be available soon. This is only a brief overview.
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -3,31 +3,25 @@ use serde::Deserialize;
 use std::str::FromStr;
 
 #[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
-pub struct ApnsCertificateConfig {
-    pub cert_path: String,
-    pub password: String,
-    pub sandbox: Option<bool>,
-}
-
-#[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
-pub struct ApnsTokenConfig {
-    pub token_path: String,
-    pub team_id: String,
-    pub key_id: String,
-    pub sandbox: Option<bool>,
-}
-
-#[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct Config {
     #[serde(default = "default_port")]
     pub port: u16,
     #[serde(default = "default_log_level")]
     pub log_level: String,
     pub database_url: String,
+
+    // TELEMETRY
     pub telemetry_enabled: Option<bool>,
     pub telemetry_grpc_url: Option<String>,
-    pub apns_certificate: Option<ApnsCertificateConfig>,
-    pub apns_token: Option<ApnsTokenConfig>,
+
+    // APNS
+    /// This defaults to false and should be changed if sandbox mode is required.
+    #[serde(default = "default_apns_sandbox_mode")]
+    pub apns_sandbox: bool,
+    pub apns_certificate: Option<String>,
+    pub apns_certificate_password: Option<String>,
+
+    // FCM
     pub fcm_api_key: Option<String>,
 }
 
@@ -39,7 +33,7 @@ impl Config {
     pub fn supported_providers(&self) -> Vec<ProviderKind> {
         let mut supported = vec![];
 
-        if self.apns_certificate.is_some() || self.apns_token.is_some() {
+        if self.apns_certificate.is_some() && self.apns_certificate_password.is_some() {
             supported.push(ProviderKind::Apns)
         }
 
@@ -62,6 +56,10 @@ fn default_port() -> u16 {
 
 fn default_log_level() -> String {
     "WARN".to_string()
+}
+
+fn default_apns_sandbox_mode() -> bool {
+    false
 }
 
 pub fn get_config() -> error::Result<Config> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,4 +40,7 @@ pub enum Error {
 
     #[error("{0} is an invalid push provider as it has not been enabled")]
     ProviderNotAvailable(String),
+
+    #[error("A required environment variable cannot be found")]
+    RequiredEnvNotFound,
 }

--- a/src/providers/apns.rs
+++ b/src/providers/apns.rs
@@ -22,20 +22,6 @@ impl ApnsProvider {
             client: a2::Client::certificate(cert, password.as_str(), endpoint)?,
         })
     }
-
-    pub fn new_token<R>(
-        pem: &mut R,
-        key_id: String,
-        team_id: String,
-        endpoint: a2::Endpoint,
-    ) -> crate::error::Result<Self>
-    where
-        R: Read,
-    {
-        Ok(ApnsProvider {
-            client: a2::Client::token(pem, key_id, team_id, endpoint)?,
-        })
-    }
 }
 
 #[async_trait]

--- a/tests/env/mod.rs
+++ b/tests/env/mod.rs
@@ -27,9 +27,10 @@ fn default_config() {
             database_url: Default::default(),
             telemetry_enabled: None,
             telemetry_grpc_url: None,
+            apns_sandbox: false,
             apns_certificate: None,
-            apns_token: None,
-            fcm_api_key: None
+            fcm_api_key: None,
+            apns_certificate_password: None
         }
     )
 }
@@ -52,9 +53,10 @@ fn env_config_1() {
             database_url: Default::default(),
             telemetry_enabled: Some(false),
             telemetry_grpc_url: None,
+            apns_sandbox: false,
             apns_certificate: None,
-            apns_token: None,
-            fcm_api_key: None
+            fcm_api_key: None,
+            apns_certificate_password: None
         }
     )
 }
@@ -78,9 +80,10 @@ fn env_config_2() {
             database_url: Default::default(),
             telemetry_enabled: None,
             telemetry_grpc_url: None,
+            apns_sandbox: false,
             apns_certificate: None,
-            apns_token: None,
-            fcm_api_key: None
+            fcm_api_key: None,
+            apns_certificate_password: None
         }
     )
 }
@@ -104,9 +107,10 @@ fn env_config_3() {
             database_url: Default::default(),
             telemetry_enabled: None,
             telemetry_grpc_url: None,
+            apns_sandbox: false,
             apns_certificate: None,
-            apns_token: None,
-            fcm_api_key: None
+            fcm_api_key: None,
+            apns_certificate_password: None
         }
     )
 }
@@ -133,9 +137,10 @@ fn env_config_4() {
             database_url: Default::default(),
             telemetry_enabled: Some(true),
             telemetry_grpc_url: Some("http://localhost:4317".to_string()),
+            apns_sandbox: false,
             apns_certificate: None,
-            apns_token: None,
-            fcm_api_key: Some("API-KEY".to_string())
+            fcm_api_key: Some("API-KEY".to_string()),
+            apns_certificate_password: None
         }
     )
 }


### PR DESCRIPTION
# Description
Fixes the APNS config being broken. Removes support for token based APNS as well as adding a list of supported push providers to the README.md

## How Has This Been Tested?
`cargo test`

## Due Diligence

* [x] Breaking change
* [x] Requires a documentation update
* [x] Requires a e2e/integration test update