### PR TITLE
fix: Only release on manual trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,32 +1,14 @@
 name: release
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '.github/**'
-      - 'terraform/**'
-      - 'docs/**'
-      - 'README.md'
   workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
-  check-not-ci:
-    runs-on: ubuntu-latest
-    outputs:
-      pusher: ${{ steps.check.outputs.pusher }}
-    steps:
-      - id: check
-        run: |
-          echo "pusher=${{ github.event.pusher.name }}" >> $GITHUB_OUTPUT
-
   release:
     runs-on: ubuntu-latest
-    if: needs.check-not-ci.outputs.pusher != 'github-actions[bot]'
     needs:
       - check-not-ci
     steps:


### PR DESCRIPTION
# Description
Each push to main was going to trigger a release where-as we only want to release every so often as it rebuilds/redeploys as well as creating new containers

## How Has This Been Tested?
N/a, cannot test actions

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update