### PR TITLE
feat: allow updating device token

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -60,9 +60,6 @@ pub enum Error {
     #[error("the `{0}` field must not be empty")]
     EmptyField(String),
 
-    #[error("a client is already registered with the provided identifier")]
-    ClientAlreadyRegistered,
-
     #[error("a required environment variable cannot be found")]
     RequiredEnvNotFound,
 
@@ -139,17 +136,6 @@ impl IntoResponse for Error {
                     message: e.to_string(),
                 }
             ], vec![]),
-            Error::ClientAlreadyRegistered => crate::handlers::Response::new_failure(
-                StatusCode::BAD_REQUEST,
-                vec![],
-                vec![
-                    ErrorField {
-                        field: "client_id".to_string(),
-                        description: "Client already registered with the provided identifier".to_string(),
-                        location: ErrorLocation::Body,
-                    }
-                ],
-            ),
             Error::Store(e) => match e {
                 StoreError::Database(e) => crate::handlers::Response::new_failure(
                     StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/handlers/register_client.rs
+++ b/src/handlers/register_client.rs
@@ -1,11 +1,7 @@
 use {
     crate::{
         error::{
-            Error::{
-                EmptyField,
-                IncludedTenantIdWhenNotNeeded,
-                ProviderNotAvailable,
-            },
+            Error::{EmptyField, IncludedTenantIdWhenNotNeeded, ProviderNotAvailable},
             Result,
         },
         handlers::Response,

--- a/src/handlers/register_client.rs
+++ b/src/handlers/register_client.rs
@@ -2,7 +2,6 @@ use {
     crate::{
         error::{
             Error::{
-                ClientAlreadyRegistered,
                 EmptyField,
                 IncludedTenantIdWhenNotNeeded,
                 ProviderNotAvailable,
@@ -61,7 +60,15 @@ pub async fn handler(
     };
 
     if exists {
-        return Err(ClientAlreadyRegistered);
+        state
+        .client_store
+        .update_client(&tenant_id, &body.client_id, Client {
+            push_type,
+            token: body.token,
+        })
+        .await?;
+
+        return Ok(Response::default());
     }
 
     state

--- a/src/handlers/register_client.rs
+++ b/src/handlers/register_client.rs
@@ -10,7 +10,7 @@ use {
         },
         handlers::Response,
         state::{AppState, State},
-        stores::{client::Client, StoreError},
+        stores::client::Client,
     },
     axum::extract::{Json, Path, State as StateExtractor},
     serde::{Deserialize, Serialize},
@@ -43,32 +43,6 @@ pub async fn handler(
 
     if body.token.is_empty() {
         return Err(EmptyField("token".to_string()));
-    }
-
-    let exists = match state
-        .client_store
-        .get_client(&tenant_id, &body.client_id)
-        .await
-    {
-        Ok(_) => true,
-        Err(e) => match e {
-            StoreError::Database(db_error) => {
-                return Err(db_error.into());
-            }
-            StoreError::NotFound(_, _) => false,
-        },
-    };
-
-    if exists {
-        state
-        .client_store
-        .update_client(&tenant_id, &body.client_id, Client {
-            push_type,
-            token: body.token,
-        })
-        .await?;
-
-        return Ok(Response::default());
     }
 
     state

--- a/src/stores/client.rs
+++ b/src/stores/client.rs
@@ -28,7 +28,7 @@ impl ClientStore for sqlx::PgPool {
             "INSERT INTO public.clients (id, tenant_id, push_type, device_token)",
         );
         query_builder.push_values(
-            vec![(id, tenant_id, client.push_type, client.clone().token)],
+            vec![(id, tenant_id, client.push_type, client.token)],
             |mut b, client| {
                 b.push_bind(client.0)
                     .push_bind(client.1)

--- a/src/stores/tenant.rs
+++ b/src/stores/tenant.rs
@@ -55,7 +55,10 @@ impl Tenant {
     pub fn providers(&self) -> Vec<ProviderKind> {
         let mut supported = vec![];
 
-        if self.apns_certificate.is_some() && self.apns_certificate_password.is_some() && self.apns_topic.is_some() {
+        if self.apns_certificate.is_some()
+            && self.apns_certificate_password.is_some()
+            && self.apns_topic.is_some()
+        {
             supported.push(ProviderKind::Apns);
         }
 

--- a/tests/functional/registration.rs
+++ b/tests/functional/registration.rs
@@ -9,12 +9,31 @@ async fn test_registration(ctx: &mut ServerContext) {
     let charset = "1234567890";
     let random_client_id = generate(12, charset);
     let payload = RegisterBody {
-        client_id: random_client_id,
+        client_id: random_client_id.clone(),
         push_type: "noop".to_string(),
         token: "test".to_string(),
     };
 
+    // Register client
     let client = reqwest::Client::new();
+    let response = client
+        .post(format!("http://{}/clients", ctx.server.public_addr))
+        .json(&payload)
+        .send()
+        .await
+        .expect("Call failed");
+
+    assert!(
+        response.status().is_success(),
+        "Response was not successful"
+    );
+
+    // Update token
+    let payload = RegisterBody {
+        client_id: random_client_id,
+        push_type: "noop".to_string(),
+        token: "new_token".to_string(),
+    };
     let response = client
         .post(format!("http://{}/clients", ctx.server.public_addr))
         .json(&payload)

--- a/tests/functional/registration.rs
+++ b/tests/functional/registration.rs
@@ -1,7 +1,9 @@
-use echo_server::handlers::register_client::RegisterBody;
-use random_string::generate;
-
-use {crate::context::ServerContext, test_context::test_context};
+use {
+    crate::context::ServerContext,
+    echo_server::handlers::register_client::RegisterBody,
+    random_string::generate,
+    test_context::test_context,
+};
 
 #[test_context(ServerContext)]
 #[tokio::test]


### PR DESCRIPTION
# Description

This is especially important for iOS: the client id remains in the keychain when the app is uninstalled/reinstalled. Hence, right now the iOS development flow is really hard.

Also: generally a 200 is a much nicer development experience compared to having to handle both a 200 and a 400.

We can handle security things e.g. who can update the token later see #57 

Resolves #29 

## How Has This Been Tested?

Covered in functional tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update