### PR TITLE
feat(ci): use larger runners in CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,7 +46,8 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
   build-container:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: ubuntu-runners
     needs:
       - get-version
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ concurrency:
 jobs:
   tasks:
     name: "[${{ matrix.os }}/rust-${{matrix.rust}}] ${{ matrix.cargo.name }}"
-    runs-on: "${{ matrix.os }}"
+    runs-on:
+      group: ubuntu-runners
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Description

Using the recently released hosted runners feature and a 16core/64gb ram runner config. In my tests test/publish steps now only take 50% of the time.

## How Has This Been Tested?

Tested in other repos

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update