### PR TITLE
fix: use self instead of unnecessary structure names

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -97,49 +97,49 @@ pub enum Error {
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
         match self {
-            Error::Apns(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
+            Self::Apns(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
                 ResponseError {
                     name: "apns".to_string(),
                     message: e.to_string(),
                 }
             ], vec![]),
-            Error::Fcm(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
+            Self::Fcm(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
                 ResponseError {
                     name: "fcm".to_string(),
                     message: e.to_string(),
                 }
             ], vec![]),
-            Error::Database(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
+            Self::Database(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
                 ResponseError {
                     name: "sqlx".to_string(),
                     message: e.to_string(),
                 }
             ], vec![]),
-            Error::Hex(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
+            Self::Hex(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
                 ResponseError {
                     name: "from_hex".to_string(),
                     message: e.to_string(),
                 }
             ], vec![]),
-            Error::Ed25519(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
+            Self::Ed25519(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
                 ResponseError {
                     name: "ed25519".to_string(),
                     message: e.to_string(),
                 }
             ], vec![]),
-            Error::HttpRequest(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
+            Self::HttpRequest(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
                 ResponseError {
                     name: "http_request".to_string(),
                     message: e.to_string(),
                 }
             ], vec![]),
-            Error::Base64Decode(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
+            Self::Base64Decode(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
                 ResponseError {
                     name: "base64_decode".to_string(),
                     message: e.to_string(),
                 }
             ], vec![]),
-            Error::Store(e) => match e {
+            Self::Store(e) => match e {
                 StoreError::Database(e) => crate::handlers::Response::new_failure(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     vec![ResponseError {
@@ -158,7 +158,7 @@ impl IntoResponse for Error {
                     }],
                 ),
             },
-            Error::ProviderNotFound(p) => crate::handlers::Response::new_failure(StatusCode::BAD_REQUEST, vec![
+            Self::ProviderNotFound(p) => crate::handlers::Response::new_failure(StatusCode::BAD_REQUEST, vec![
                 ResponseError {
                     name: "provider_not_available".to_string(),
                     message: format!("The requested provider ({}) is not a valid provider", &p),
@@ -170,7 +170,7 @@ impl IntoResponse for Error {
                     location: ErrorLocation::Body
                 }
             ]),
-            Error::ProviderNotAvailable(p) => crate::handlers::Response::new_failure(StatusCode::BAD_REQUEST, vec![
+            Self::ProviderNotAvailable(p) => crate::handlers::Response::new_failure(StatusCode::BAD_REQUEST, vec![
                 ResponseError {
                     name: "provider_not_available".to_string(),
                     message: format!("The requested provider ({}) is not currently available", &p),
@@ -182,7 +182,7 @@ impl IntoResponse for Error {
                     location: ErrorLocation::Body
                 }
             ]),
-            Error::MissingAllSignatureHeader => crate::handlers::Response::new_failure(StatusCode::UNAUTHORIZED, vec![
+            Self::MissingAllSignatureHeader => crate::handlers::Response::new_failure(StatusCode::UNAUTHORIZED, vec![
                 ResponseError {
                     name: "webhook_validation_failed".to_string(),
                     message: "Failed to validate webhook, please ensure that all required headers are provided.".to_string(),
@@ -199,7 +199,7 @@ impl IntoResponse for Error {
                     location: ErrorLocation::Header
                 }
             ]),
-            Error::MissingSignatureHeader => crate::handlers::Response::new_failure(StatusCode::UNAUTHORIZED, vec![
+            Self::MissingSignatureHeader => crate::handlers::Response::new_failure(StatusCode::UNAUTHORIZED, vec![
                 ResponseError {
                     name: "webhook_validation_failed".to_string(),
                     message: "Failed to validate webhook, please ensure that all required headers are provided.".to_string(),
@@ -211,7 +211,7 @@ impl IntoResponse for Error {
                     location: ErrorLocation::Header
                 }
             ]),
-            Error::MissingTimestampHeader => crate::handlers::Response::new_failure(StatusCode::UNAUTHORIZED, vec![
+            Self::MissingTimestampHeader => crate::handlers::Response::new_failure(StatusCode::UNAUTHORIZED, vec![
                 ResponseError {
                     name: "webhook_validation_failed".to_string(),
                     message: "Failed to validate webhook, please ensure that all required headers are provided.".to_string(),
@@ -223,7 +223,7 @@ impl IntoResponse for Error {
                     location: ErrorLocation::Header
                 }
             ]),
-            Error::InvalidTenantId(id) => crate::handlers::Response::new_failure(StatusCode::BAD_REQUEST, vec![
+            Self::InvalidTenantId(id) => crate::handlers::Response::new_failure(StatusCode::BAD_REQUEST, vec![
                 ResponseError {
                     name: "tenant".to_string(),
                     message: format!("The provided Tenant ID, {}, is invalid. Please ensure it's valid and the url is in the format /:tenant_id/...path", &id),
@@ -235,7 +235,7 @@ impl IntoResponse for Error {
                     location: ErrorLocation::Path
                 }
             ]),
-            Error::MissingTenantId => crate::handlers::Response::new_failure(
+            Self::MissingTenantId => crate::handlers::Response::new_failure(
                 StatusCode::BAD_REQUEST,
                 vec![ResponseError {
                     name: "tenancy-mode".to_string(),
@@ -243,7 +243,7 @@ impl IntoResponse for Error {
                 }],
                 vec![],
             ),
-            Error::IncludedTenantIdWhenNotNeeded => crate::handlers::Response::new_failure(
+            Self::IncludedTenantIdWhenNotNeeded => crate::handlers::Response::new_failure(
                 StatusCode::BAD_REQUEST,
                 vec![ResponseError {
                     name: "tenancy-mode".to_string(),

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -52,7 +52,7 @@ pub struct Response {
 
 impl Response {
     pub fn new_success(status: StatusCode) -> Self {
-        Response {
+        Self {
             status: ResponseStatus::Success,
             status_code: status,
             errors: None,
@@ -65,7 +65,7 @@ impl Response {
         errors: Vec<ResponseError>,
         fields: Vec<ErrorField>,
     ) -> Self {
-        Response {
+        Self {
             status: ResponseStatus::Failure,
             status_code: status,
             errors: Some(errors),
@@ -85,12 +85,12 @@ impl IntoResponse for Response {
 
 impl From<Response> for Json<Value> {
     fn from(value: Response) -> Self {
-        Json(json!(value))
+        Self(json!(value))
     }
 }
 
 impl Default for Response {
     fn default() -> Self {
-        Response::new_success(StatusCode::OK)
+        Self::new_success(StatusCode::OK)
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -36,7 +36,7 @@ impl Metrics {
             .with_description("The number of notification received")
             .init();
 
-        Ok(Metrics {
+        Ok(Self {
             prometheus_exporter: exporter,
             registered_webhooks: hooks_counter,
             received_notifications: notification_counter,

--- a/src/providers/apns.rs
+++ b/src/providers/apns.rs
@@ -22,7 +22,7 @@ impl ApnsProvider {
     where
         R: Read,
     {
-        Ok(ApnsProvider {
+        Ok(Self {
             client: a2::Client::certificate(cert, password.as_str(), endpoint)?,
             topic,
         })

--- a/src/providers/fcm.rs
+++ b/src/providers/fcm.rs
@@ -13,7 +13,7 @@ pub struct FcmProvider {
 
 impl FcmProvider {
     pub fn new(api_key: String) -> Self {
-        FcmProvider {
+        Self {
             api_key,
             client: fcm::Client::new(),
         }
@@ -50,7 +50,7 @@ impl PushProvider for FcmProvider {
 
 impl Clone for FcmProvider {
     fn clone(&self) -> Self {
-        FcmProvider {
+        Self {
             api_key: self.api_key.clone(),
             client: fcm::Client::new(),
         }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -100,10 +100,10 @@ impl PushProvider for Provider {
         let s = span!(tracing::Level::INFO, "send_notification");
         let _ = s.enter();
         match self {
-            Provider::Fcm(p) => p.send_notification(token, payload).await,
-            Provider::Apns(p) => p.send_notification(token, payload).await,
+            Self::Fcm(p) => p.send_notification(token, payload).await,
+            Self::Apns(p) => p.send_notification(token, payload).await,
             #[cfg(any(debug_assertions, test))]
-            Provider::Noop(p) => p.send_notification(token, payload).await,
+            Self::Noop(p) => p.send_notification(token, payload).await,
         }
     }
 }

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -15,8 +15,8 @@ pub struct RelayClient {
 }
 
 impl RelayClient {
-    pub fn new(base_url: String) -> RelayClient {
-        RelayClient {
+    pub fn new(base_url: String) -> Self {
+        Self {
             http_client: reqwest::Client::new(),
             base_url,
             public_key: None,

--- a/src/stores/tenant.rs
+++ b/src/stores/tenant.rs
@@ -203,8 +203,8 @@ impl TenantWriteStore for PgPool {
 pub struct DefaultTenantStore(Tenant);
 
 impl DefaultTenantStore {
-    pub fn new(config: Arc<Config>) -> Result<DefaultTenantStore> {
-        Ok(DefaultTenantStore(Tenant {
+    pub fn new(config: Arc<Config>) -> Result<Self> {
+        Ok(Self(Tenant {
             id: config.default_tenant_id.clone(),
             fcm_api_key: config.fcm_api_key.clone(),
             apns_sandbox: config.apns_sandbox,


### PR DESCRIPTION
# Description

When looking into `echo-server` implementation I've noticed that sometimes structure names are being used where `Self` can be used instead (clippy has it under [use_self](https://rust-lang.github.io/rust-clippy/master/index.html#use_self) lint). So, I've run linter to see all the places that can be updated, hence this PR. 

## How Has This Been Tested?

When running `cargo test` only 3 tests are located, so I'm not sure how this should be tested (I've made sure that code whenever updated makes sense -- not sure if that is enough).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update