### PR TITLE
feat: Statically compile echo-server and run on scratch image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "echo-server"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "a2",
  "async-trait",
@@ -574,6 +574,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hyper",
+ "openssl",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-prometheus",
@@ -1378,6 +1379,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.24.0+1.1.1s"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +1396,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ base64 = "0.13"
 chrono = "0.4"
 uuid = { version = "1.2", features = ["v4"] }
 
+# Vendored to allow static compilation
+openssl = { version = "*", features = ["vendored"] }
+
 [dev-dependencies]
 serial_test = "0.9"
 test-context = "0.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@
 #
 ################################################################################
 ARG                 base="rust:buster"
-ARG                 runtime="debian:buster-slim"
+ARG                 runtime="scratch"
 ARG                 bin="echo-server"
 ARG                 version="unknown"
 ARG                 sha="unknown"
 ARG                 maintainer="WalletConnect"
 ARG                 release=""
-
+ARG                 target="x86_64-unknown-linux-musl"
 ################################################################################
 #
 # Install cargo-chef
@@ -41,15 +41,31 @@ RUN                 cargo chef prepare --recipe-path recipe.json
 FROM                chef AS build
 
 ARG                 release
+ARG                 target
 ENV                 RELEASE=${release:+--release}
+ENV                 TARGET=${target:+"--target ${target}"}
 
 WORKDIR             /app
 # Cache dependancies
 COPY --from=plan    /app/recipe.json recipe.json
-RUN                 cargo chef cook --recipe-path recipe.json ${RELEASE}
+
+# Install system dependencies for static compilation + be ported into scratch
+RUN                 if [ -n "$target" ] ; then rustup target add ${target} ; fi
+RUN                 apt-get update \
+                        && apt-get install -y --no-install-recommends \
+                          ca-certificates \
+                          libssl-dev \
+                          pkg-config \
+                          musl \
+                          musl-tools \
+                        && apt-get clean \
+                        && rm -rf /var/lib/apt/lists/*
+
+RUN                 cargo chef cook --recipe-path recipe.json ${RELEASE} ${TARGET}
 # Build the local binary
 COPY                . .
-RUN                 cargo build --bin echo-server ${RELEASE}
+RUN                 cargo build --bin echo-server ${RELEASE} ${TARGET}
+
 
 ################################################################################
 #
@@ -63,6 +79,7 @@ ARG                 version
 ARG                 sha
 ARG                 maintainer
 ARG                 release
+ARG                 target
 ARG                 binpath=${release:+release}
 
 LABEL               version=${version}
@@ -70,11 +87,10 @@ LABEL               sha=${sha}
 LABEL               maintainer=${maintainer}
 
 WORKDIR             /app
-COPY --from=build   /app/target/${binpath:-debug}/echo-server /usr/local/bin/echo-server
-RUN                 apt-get update \
-                        && apt-get install -y --no-install-recommends ca-certificates libssl-dev \
-                        && apt-get clean \
-                        && rm -rf /var/lib/apt/lists/*
+COPY --from=build   /app/target/${target:+"${target}/"}${binpath:-debug}/echo-server /usr/local/bin/echo-server
+COPY --from=build   /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build   /etc/passwd /etc/passwd
 
 USER                1001:1001
+
 ENTRYPOINT          ["/usr/local/bin/echo-server"]


### PR DESCRIPTION
# Description

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

This is an opinionated PR that was finagled to fit the current approach set in the `Dockerfile` so feel free to reject or manipulate into something that works. We prefer to statically compile binaries so we can run them on `scratch`, when possible, to minimize surface area for attacks.

The previous build behavior, though not exact, is possible by supplying `runtime=debian:buster-slim` and `target=''` as build args. 

There are things to think about regarding the `Dockerfile` and its intended usage since there are currently some ideas that are incompatible/awkward:
- `runtime` is a build arg which implies it can be changed, but before this PR, compilation would fail on non-debian based distros due to `apt-get` usage 
     - After this PR, it make less sense since echo-server is compiled statically and we copy all necessary files over from the `build` stage. Providing `runtime=debian:buster-slim` will still work though! 
- The introduction of `target` by me isn't an ideal solution because (providing `target='' will still work though`): 
     - different targets have their own system dependencies that need to be installed in the `build` stage 
     - different `runtime` options may be incompatible with the `target` (e.g., mismatched archs)
    
## How Has This Been Tested?

I brought up services via docker-compose and verified echo-server boots, handles a request correctly, and is terminated properly.

I tested with following combos:
- `target=''` and `runtime=debian:buster-slim`
- `target=x86_64-unknown-linux-musl` and `runtime=scratch`

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update