### PR TITLE
fix: lowercase string conversions into ProviderKind

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -75,7 +75,7 @@ impl TryFrom<&str> for ProviderKind {
     type Error = error::Error;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        match value {
+        match value.to_lowercase().as_str() {
             PROVIDER_APNS => Ok(Self::Apns),
             PROVIDER_APNS_SANDBOX => Ok(Self::ApnsSandbox),
             PROVIDER_FCM => Ok(Self::Fcm),


### PR DESCRIPTION
# Description

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Since push notification registration is not handled by the SDK, the implementation burden is on the wallet, and open to input errors like sending `type` as `FCM` and not `fcm`. This is not worth rejecting as a validation error since it is reconcilable by the echo-server backend.

## How Has This Been Tested?

I manually tested this, it's a pretty straightforward fix.

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update