### PR TITLE
fix: Strip out decentralized identifier prefix from client_id

### DIFF
--- a/src/handlers/delete_client.rs
+++ b/src/handlers/delete_client.rs
@@ -1,5 +1,10 @@
 use {
-    crate::{error::Result, handlers::Response, log::prelude::*, state::AppState},
+    crate::{
+        error::Result,
+        handlers::{Response, DECENTRALIZED_IDENTIFIER_PREFIX},
+        log::prelude::*,
+        state::AppState,
+    },
     axum::extract::{Path, State as StateExtractor},
     opentelemetry::Context,
     std::sync::Arc,
@@ -9,6 +14,10 @@ pub async fn handler(
     Path((tenant_id, id)): Path<(String, String)>,
     StateExtractor(state): StateExtractor<Arc<AppState>>,
 ) -> Result<Response> {
+    let id = id
+        .trim_start_matches(DECENTRALIZED_IDENTIFIER_PREFIX)
+        .to_string();
+
     state.client_store.delete_client(&tenant_id, &id).await?;
     info!("client ({}) deleted for tenant ({})", id, tenant_id);
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -18,6 +18,8 @@ pub mod get_tenant;
 pub mod update_apns;
 pub mod update_fcm;
 
+pub const DECENTRALIZED_IDENTIFIER_PREFIX: &str = "did:key:";
+
 #[derive(serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ErrorLocation {

--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         blob::ENCRYPTED_FLAG,
         error::Result,
-        handlers::Response,
+        handlers::{Response, DECENTRALIZED_IDENTIFIER_PREFIX},
         log::prelude::*,
         middleware::validate_signature::RequireValidSignature,
         providers::PushProvider,
@@ -47,6 +47,10 @@ pub async fn handler(
             .add(&Context::current(), 1, &[]);
         debug!("incremented `received_notifications` counter")
     }
+
+    let id = id
+        .trim_start_matches(DECENTRALIZED_IDENTIFIER_PREFIX)
+        .to_string();
 
     let client = state.client_store.get_client(&tenant_id, &id).await?;
     info!("fetched client ({}) for tenant ({})", &id, &tenant_id);

--- a/src/handlers/register_client.rs
+++ b/src/handlers/register_client.rs
@@ -4,7 +4,7 @@ use {
             Error::{EmptyField, ProviderNotAvailable},
             Result,
         },
-        handlers::Response,
+        handlers::{Response, DECENTRALIZED_IDENTIFIER_PREFIX},
         log::prelude::*,
         state::AppState,
         stores::client::Client,
@@ -39,9 +39,13 @@ pub async fn handler(
         return Err(EmptyField("token".to_string()));
     }
 
+    let client_id = body
+        .client_id
+        .trim_start_matches(DECENTRALIZED_IDENTIFIER_PREFIX);
+
     state
         .client_store
-        .create_client(&tenant_id, &body.client_id, Client {
+        .create_client(&tenant_id, &client_id, Client {
             push_type,
             token: body.token,
         })

--- a/src/handlers/register_client.rs
+++ b/src/handlers/register_client.rs
@@ -45,7 +45,7 @@ pub async fn handler(
 
     state
         .client_store
-        .create_client(&tenant_id, &client_id, Client {
+        .create_client(&tenant_id, client_id, Client {
             push_type,
             token: body.token,
         })

--- a/src/handlers/single_tenant_wrappers.rs
+++ b/src/handlers/single_tenant_wrappers.rs
@@ -1,12 +1,7 @@
 use {
     crate::{
         error::{Error::MissingTenantId, Result},
-        handlers::{
-            push_message::PushMessageBody,
-            register_client::RegisterBody,
-            Response,
-            DECENTRALIZED_IDENTIFIER_PREFIX,
-        },
+        handlers::{push_message::PushMessageBody, register_client::RegisterBody, Response},
         middleware::validate_signature::RequireValidSignature,
         state::{AppState, State},
     },
@@ -25,10 +20,6 @@ pub async fn delete_handler(
         return Err(MissingTenantId);
     }
 
-    let id = id
-        .trim_start_matches(DECENTRALIZED_IDENTIFIER_PREFIX)
-        .to_string();
-
     crate::handlers::delete_client::handler(
         Path((state.config.default_tenant_id.clone(), id)),
         state,
@@ -44,10 +35,6 @@ pub async fn push_handler(
     if state.is_multitenant() {
         return Err(MissingTenantId);
     }
-
-    let id = id
-        .trim_start_matches(DECENTRALIZED_IDENTIFIER_PREFIX)
-        .to_string();
 
     crate::handlers::push_message::handler(
         Path((state.config.default_tenant_id.clone(), id)),

--- a/src/handlers/single_tenant_wrappers.rs
+++ b/src/handlers/single_tenant_wrappers.rs
@@ -1,7 +1,12 @@
 use {
     crate::{
         error::{Error::MissingTenantId, Result},
-        handlers::{push_message::PushMessageBody, register_client::RegisterBody, Response},
+        handlers::{
+            push_message::PushMessageBody,
+            register_client::RegisterBody,
+            Response,
+            DECENTRALIZED_IDENTIFIER_PREFIX,
+        },
         middleware::validate_signature::RequireValidSignature,
         state::{AppState, State},
     },
@@ -20,6 +25,10 @@ pub async fn delete_handler(
         return Err(MissingTenantId);
     }
 
+    let id = id
+        .trim_start_matches(DECENTRALIZED_IDENTIFIER_PREFIX)
+        .to_string();
+
     crate::handlers::delete_client::handler(
         Path((state.config.default_tenant_id.clone(), id)),
         state,
@@ -35,6 +44,10 @@ pub async fn push_handler(
     if state.is_multitenant() {
         return Err(MissingTenantId);
     }
+
+    let id = id
+        .trim_start_matches(DECENTRALIZED_IDENTIFIER_PREFIX)
+        .to_string();
 
     crate::handlers::push_message::handler(
         Path((state.config.default_tenant_id.clone(), id)),


### PR DESCRIPTION
# Description

https://github.com/WalletConnect/echo-server/blob/main/Contributors.md#client-registration suggests that you can just pass the output of the SDK function that returns Client ID, but this is not true for at least the javascript SDK, which returns the client ID in 
the format `did:key:foo`. The echo-server will happily accept this, but will prove to be problematic when the notification endpoint gets client ID without this prefix.

This PR just strips out this prefix for the three endpoints.

## How Has This Been Tested?

Manually tested

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update