### PR TITLE
fix: tenant url

### DIFF
--- a/src/handlers/create_tenant.rs
+++ b/src/handlers/create_tenant.rs
@@ -37,6 +37,6 @@ pub async fn handler(
     let tenant = state.tenant_store.create_tenant(params).await?;
 
     Ok(Json(TenantRegisterResponse {
-        url: format!("{}/tenants/{}", state.config.public_url, tenant.id),
+        url: format!("{}/{}", state.config.public_url, tenant.id),
     }))
 }

--- a/src/handlers/get_tenant.rs
+++ b/src/handlers/get_tenant.rs
@@ -24,7 +24,7 @@ pub async fn handler(
     let providers = tenant.providers();
 
     let mut res = GetTenantResponse {
-        url: format!("{}/tenants/{}", state.config.public_url, tenant.id),
+        url: format!("{}/{}", state.config.public_url, tenant.id),
         enabled_providers: tenant.providers().iter().map(Into::into).collect(),
         apns_topic: None,
     };


### PR DESCRIPTION
# Description
The generated URLs are wrong, we don't use the `/tenant/` prefix

## How Has This Been Tested?
N/a

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update