### PR TITLE
fix: apns support

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,4 +40,4 @@ jobs:
       - run: yarn integration:$ENVIRONMENT
         env:
           ENVIRONMENT: ${{ inputs.environment }}
-          TEST_TENANT_ID_APNS: ${{ secrets.TEST_TENANT_ID }}
+          TEST_TENANT_ID: ${{ secrets.TEST_TENANT_ID }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 
 [[package]]
 name = "echo-server"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "a2",
  "async-trait",

--- a/src/error.rs
+++ b/src/error.rs
@@ -123,6 +123,9 @@ pub enum Error {
 
     #[error("client cannot be found")]
     ClientNotFound,
+
+    #[error("this should not have occurred; used when case has been handled before")]
+    InternalServerError,
 }
 
 impl IntoResponse for Error {

--- a/src/handlers/create_tenant.rs
+++ b/src/handlers/create_tenant.rs
@@ -24,18 +24,7 @@ pub async fn handler(
     // TODO authentication
     // TODO validation
 
-    let params = TenantUpdateParams {
-        id: Some(body.id),
-
-        fcm_api_key: None,
-
-        apns_topic: None,
-        apns_certificate: None,
-        apns_certificate_password: None,
-        apns_pkcs8_pem: None,
-        apns_key_id: None,
-        apns_team_id: None,
-    };
+    let params = TenantUpdateParams { id: body.id };
 
     let tenant = state.tenant_store.create_tenant(params).await?;
 

--- a/src/handlers/get_tenant.rs
+++ b/src/handlers/get_tenant.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{error::Error, providers::ProviderKind, state::AppState},
+    crate::{error::Error, providers::ProviderKind, state::AppState, stores::tenant::ApnsType},
     axum::{
         extract::{Path, State},
         Json,
@@ -13,6 +13,7 @@ pub struct GetTenantResponse {
     url: String,
     enabled_providers: Vec<String>,
     apns_topic: Option<String>,
+    apns_type: Option<ApnsType>,
 }
 
 pub async fn handler(
@@ -27,10 +28,12 @@ pub async fn handler(
         url: format!("{}/{}", state.config.public_url, tenant.id),
         enabled_providers: tenant.providers().iter().map(Into::into).collect(),
         apns_topic: None,
+        apns_type: None,
     };
 
     if providers.contains(&ProviderKind::Apns) {
         res.apns_topic = tenant.apns_topic;
+        res.apns_type = tenant.apns_type;
     }
 
     Ok(Json(res))

--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         blob::ENCRYPTED_FLAG,
         error::{
-            Error::{self, ClientNotFound, Store},
+            Error::{ClientNotFound, Store},
             Result,
         },
         handlers::{Response, DECENTRALIZED_IDENTIFIER_PREFIX},

--- a/src/handlers/update_apns.rs
+++ b/src/handlers/update_apns.rs
@@ -116,8 +116,8 @@ pub async fn handler(
 
     let apns_type = body.validate()?;
 
-    if let None = apns_type {
-        // Just update topic!
+    if apns_type.is_none() {
+        // Just update topic
         let update_body = TenantApnsUpdateParams {
             apns_topic: body.apns_topic,
             apns_type: existing_tenant.apns_type,

--- a/src/handlers/update_fcm.rs
+++ b/src/handlers/update_fcm.rs
@@ -3,7 +3,7 @@ use {
         error::{Error, Error::InvalidMultipartBody},
         increment_counter,
         state::AppState,
-        stores::tenant::TenantUpdateParams,
+        stores::tenant::TenantFcmUpdateParams,
     },
     axum::{
         extract::{Multipart, Path, State},
@@ -29,6 +29,9 @@ pub async fn handler(
     Path(id): Path<String>,
     mut form_body: Multipart,
 ) -> Result<Json<UpdateTenantFcmResponse>, Error> {
+    // -- check if tenant is real
+    let _existing_tenant = state.tenant_store.get_tenant(&id).await?;
+
     // ---- retrieve body from form
     let mut body = FcmUpdateBody {
         api_key: Default::default(),
@@ -48,19 +51,14 @@ pub async fn handler(
     }
 
     // ---- handler
-    let existing_tenant = state.tenant_store.get_tenant(&id).await?;
-    let update_body = TenantUpdateParams {
-        id: Some(existing_tenant.id),
-        fcm_api_key: Some(body.api_key),
-        apns_topic: existing_tenant.apns_topic,
-        apns_certificate: existing_tenant.apns_certificate,
-        apns_certificate_password: existing_tenant.apns_certificate_password,
-        apns_pkcs8_pem: existing_tenant.apns_pkcs8_pem,
-        apns_key_id: existing_tenant.apns_key_id,
-        apns_team_id: existing_tenant.apns_team_id,
+    let update_body = TenantFcmUpdateParams {
+        fcm_api_key: body.api_key,
     };
 
-    let _new_tenant = state.tenant_store.update_tenant(update_body).await?;
+    let _new_tenant = state
+        .tenant_store
+        .update_tenant_fcm(&id, update_body)
+        .await?;
 
     increment_counter!(state.metrics, tenant_fcm_updates);
 


### PR DESCRIPTION
# Description
APNS wasn't setting type so it was always disabled for new staging projects, changes never reached production so no migration needed.

This also splits the updating methods to allow FCM & APNS to be updated independently of each other

## How Has This Been Tested?
N/a

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update