### PR TITLE
feat: `client_id` auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +214,12 @@ checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "build-info"
@@ -528,6 +543,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,7 +621,7 @@ checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 
 [[package]]
 name = "echo-server"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "a2",
  "async-trait",
@@ -610,18 +631,21 @@ dependencies = [
  "build-info",
  "build-info-build",
  "chrono",
+ "data-encoding",
  "dotenv",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "envy",
  "fcm",
  "futures-util",
  "hex",
  "hyper",
+ "jsonwebtoken",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-prometheus",
  "prometheus",
  "random-string",
+ "relay_rpc",
  "reqwest",
  "serde",
  "serde_json",
@@ -653,6 +677,19 @@ name = "ed25519-dalek"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "git+https://github.com/dalek-cryptography/ed25519-dalek.git?rev=7529d65#7529d65506147b6cb24ca6d8f4fc062cac33b395"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1196,6 +1233,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f4f04699947111ec1733e71778d763555737579e44b85844cae8e1940a1828"
+dependencies = [
+ "base64 0.13.1",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,6 +1695,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,6 +2009,8 @@ version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -1966,6 +2028,25 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "relay_rpc"
+version = "0.1.0"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?tag=v0.3.0#690ce83853f3e1c54779894c3f4230bdb1950695"
+dependencies = [
+ "bs58",
+ "chrono",
+ "data-encoding",
+ "derive_more",
+ "ed25519-dalek 1.0.1 (git+https://github.com/dalek-cryptography/ed25519-dalek.git?rev=7529d65)",
+ "once_cell",
+ "rand 0.7.3",
+ "regex",
+ "serde",
+ "serde-aux",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "remove_dir_all"
@@ -2143,6 +2224,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-aux"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c599b3fd89a75e0c18d6d2be693ddb12cccaf771db4ff9e39097104808a014c0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,6 +2360,18 @@ name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time 0.3.17",
+]
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,11 @@ fcm = "0.9"
 # Signature validation
 ed25519-dalek = "1.0"
 
+# JWT Authentication
+relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", tag = "v0.3.0" }
+jsonwebtoken = "8.1"
+data-encoding = "2.3"
+
 # Misc
 reqwest = "0.11"
 async-trait = "0.1"

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -4,7 +4,7 @@ use {
     std::collections::HashSet,
 };
 
-#[derive(Debug, ThisError)]
+#[derive(Debug, thiserror::Error)]
 pub enum JwtVerificationError {
     #[error("Invalid format")]
     Format,

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -1,0 +1,123 @@
+pub use relay_rpc::domain::*;
+use {
+    relay_rpc::auth::{JwtClaims, JwtHeader, DID_DELIMITER, DID_METHOD, DID_PREFIX, JWT_DELIMITER},
+    std::collections::HashSet,
+};
+
+#[derive(Debug, ThisError)]
+pub enum JwtVerificationError {
+    #[error("Invalid format")]
+    Format,
+
+    #[error("Invalid encoding")]
+    Encoding,
+
+    #[error("Invalid JWT signing algorithm")]
+    Header,
+
+    #[error("Invalid claims")]
+    Claims,
+
+    #[error("Invalid signature")]
+    Signature,
+
+    #[error("Invalid JSON")]
+    Serialization,
+
+    #[error("Invalid issuer DID prefix")]
+    IssuerPrefix,
+
+    #[error("Invalid issuer DID method")]
+    IssuerMethod,
+
+    #[error("Invalid issuer format")]
+    IssuerFormat,
+
+    #[error(transparent)]
+    PubKey(#[from] ClientIdDecodingError),
+}
+
+#[derive(Debug)]
+pub struct Jwt(pub String);
+
+impl Jwt {
+    pub(crate) fn decode(&self, aud: &HashSet<String>) -> Result<ClientId, JwtVerificationError> {
+        let mut parts = self.0.splitn(3, JWT_DELIMITER);
+
+        let (Some(header), Some(claims)) = (parts.next(), parts.next()) else {
+            return Err(JwtVerificationError::Format);
+        };
+
+        let decoder = &data_encoding::BASE64URL_NOPAD;
+
+        let header_len = decoder
+            .decode_len(header.len())
+            .map_err(|_| JwtVerificationError::Encoding)?;
+        let claims_len = decoder
+            .decode_len(claims.len())
+            .map_err(|_| JwtVerificationError::Encoding)?;
+
+        let mut output = vec![0u8; header_len.max(claims_len)];
+
+        // Decode header.
+        data_encoding::BASE64URL_NOPAD
+            .decode_mut(header.as_bytes(), &mut output[..header_len])
+            .map_err(|_| JwtVerificationError::Encoding)?;
+
+        {
+            let header = serde_json::from_slice::<JwtHeader>(&output[..header_len])
+                .map_err(|_| JwtVerificationError::Serialization)?;
+
+            if !header.is_valid() {
+                return Err(JwtVerificationError::Header);
+            }
+        }
+
+        // Decode claims.
+        data_encoding::BASE64URL_NOPAD
+            .decode_mut(claims.as_bytes(), &mut output[..claims_len])
+            .map_err(|_| JwtVerificationError::Encoding)?;
+
+        let claims = serde_json::from_slice::<JwtClaims>(&output[..claims_len])
+            .map_err(|_| JwtVerificationError::Serialization)?;
+
+        // Basic token validation: `iat`, `exp` and `aud`.
+        if !claims.is_valid(aud, None) {
+            return Err(JwtVerificationError::Claims);
+        }
+
+        let did_key = claims
+            .iss
+            .strip_prefix(DID_PREFIX)
+            .ok_or(JwtVerificationError::IssuerPrefix)?
+            .strip_prefix(DID_DELIMITER)
+            .ok_or(JwtVerificationError::IssuerFormat)?
+            .strip_prefix(DID_METHOD)
+            .ok_or(JwtVerificationError::IssuerMethod)?
+            .strip_prefix(DID_DELIMITER)
+            .ok_or(JwtVerificationError::IssuerFormat)?;
+
+        let pub_key = did_key.parse::<DecodedClientId>()?;
+
+        let mut parts = self.0.rsplitn(2, JWT_DELIMITER);
+
+        let (Some(signature), Some(message)) = (parts.next(), parts.next()) else {
+            return Err(JwtVerificationError::Format);
+        };
+
+        let key = jsonwebtoken::DecodingKey::from_ed_der(pub_key.as_ref());
+
+        // Finally, verify signature.
+        let sig_result = jsonwebtoken::crypto::verify(
+            signature,
+            message.as_bytes(),
+            &key,
+            jsonwebtoken::Algorithm::EdDSA,
+        );
+
+        match sig_result {
+            Ok(true) => Ok(pub_key.into()),
+            _ => Err(JwtVerificationError::Signature),
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,6 +55,9 @@ pub enum Error {
     #[error(transparent)]
     Store(#[from] StoreError),
 
+    #[error(transparent)]
+    ToStr(#[from] axum::http::header::ToStrError),
+
     #[error("database migration failed: {0}")]
     DatabaseMigration(#[from] sqlx::migrate::MigrateError),
 

--- a/src/handlers/delete_client.rs
+++ b/src/handlers/delete_client.rs
@@ -18,7 +18,7 @@ pub async fn handler(
     StateExtractor(state): StateExtractor<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Result<Response> {
-    if !authenticate_client(headers, |client_id| {
+    if !authenticate_client(headers, &state.config.public_url, |client_id| {
         if let Some(client_id) = client_id {
             &client_id == &body.client_id
         } else {

--- a/src/handlers/delete_client.rs
+++ b/src/handlers/delete_client.rs
@@ -1,19 +1,33 @@
 use {
     crate::{
         decrement_counter,
-        error::Result,
-        handlers::{Response, DECENTRALIZED_IDENTIFIER_PREFIX},
+        error::{Error::InvalidAuthentication, Result},
+        handlers::{authenticate_client, Response, DECENTRALIZED_IDENTIFIER_PREFIX},
         log::prelude::*,
         state::AppState,
     },
-    axum::extract::{Path, State as StateExtractor},
+    axum::{
+        extract::{Path, State as StateExtractor},
+        http::HeaderMap,
+    },
     std::sync::Arc,
 };
 
 pub async fn handler(
     Path((tenant_id, id)): Path<(String, String)>,
     StateExtractor(state): StateExtractor<Arc<AppState>>,
+    headers: HeaderMap,
 ) -> Result<Response> {
+    if !authenticate_client(headers, |client_id| {
+        if let Some(client_id) = client_id {
+            &client_id == &body.client_id
+        } else {
+            false
+        }
+    })? {
+        return Err(InvalidAuthentication);
+    }
+
     let id = id
         .trim_start_matches(DECENTRALIZED_IDENTIFIER_PREFIX)
         .to_string();

--- a/src/handlers/delete_client.rs
+++ b/src/handlers/delete_client.rs
@@ -24,6 +24,7 @@ pub async fn handler(
         .to_string();
 
     let client_to_be_deleted = ClientId::new(id.clone().into());
+    dbg!(&state.config.public_url);
     if !authenticate_client(headers, &state.config.public_url, |client_id| {
         if let Some(client_id) = client_id {
             client_id == client_to_be_deleted

--- a/src/handlers/delete_client.rs
+++ b/src/handlers/delete_client.rs
@@ -1,4 +1,5 @@
 use {
+    super::register_client::RegisterBody,
     crate::{
         decrement_counter,
         error::{Error::InvalidAuthentication, Result},
@@ -9,6 +10,7 @@ use {
     axum::{
         extract::{Path, State as StateExtractor},
         http::HeaderMap,
+        Json,
     },
     std::sync::Arc,
 };
@@ -17,10 +19,11 @@ pub async fn handler(
     Path((tenant_id, id)): Path<(String, String)>,
     StateExtractor(state): StateExtractor<Arc<AppState>>,
     headers: HeaderMap,
+    Json(body): Json<RegisterBody>,
 ) -> Result<Response> {
     if !authenticate_client(headers, &state.config.public_url, |client_id| {
         if let Some(client_id) = client_id {
-            &client_id == &body.client_id
+            client_id == body.client_id
         } else {
             false
         }

--- a/src/handlers/delete_client.rs
+++ b/src/handlers/delete_client.rs
@@ -23,10 +23,10 @@ pub async fn handler(
         .trim_start_matches(DECENTRALIZED_IDENTIFIER_PREFIX)
         .to_string();
 
-    let delete_id = ClientId::new(id.clone().into());
+    let client_to_be_deleted = ClientId::new(id.clone().into());
     if !authenticate_client(headers, &state.config.public_url, |client_id| {
         if let Some(client_id) = client_id {
-            client_id == delete_id
+            client_id == client_to_be_deleted
         } else {
             false
         }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        authentication::Jwt,
-        error::{Error::InvalidAuthentication, Result},
-    },
+    crate::{authentication::Jwt, error::Result},
     axum::{http::HeaderMap, response::IntoResponse, Json},
     hyper::StatusCode,
     relay_rpc::domain::ClientId,
@@ -26,13 +23,14 @@ pub mod update_fcm;
 
 pub const DECENTRALIZED_IDENTIFIER_PREFIX: &str = "did:key:";
 
-pub fn authenticate_client(
-    headers: HeaderMap,
-    aud: &str,
-    check: fn(Option<ClientId>) -> bool,
-) -> Result<bool> {
+pub fn authenticate_client<F>(headers: HeaderMap, aud: &str, check: F) -> Result<bool>
+where
+    F: FnOnce(Option<ClientId>) -> bool,
+{
     return if let Some(auth_header) = headers.get(axum::http::header::AUTHORIZATION) {
-        let header_str = auth_header.to_str()?;
+        // TODO: fix unwrap
+        let header_str = auth_header.to_str().unwrap();
+        // let header_str = auth_header.to_str()?;
         let client_id = Jwt(header_str.to_string()).decode(&HashSet::from([aud.to_string()]))?;
         Ok(check(Some(client_id)))
     } else {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -7,6 +7,7 @@ use {
     hyper::StatusCode,
     relay_rpc::domain::ClientId,
     serde_json::{json, Value},
+    std::{collections::HashSet, string::ToString},
 };
 
 // Push
@@ -27,11 +28,12 @@ pub const DECENTRALIZED_IDENTIFIER_PREFIX: &str = "did:key:";
 
 pub fn authenticate_client(
     headers: HeaderMap,
+    aud: &str,
     check: fn(Option<ClientId>) -> bool,
 ) -> Result<bool> {
     return if let Some(auth_header) = headers.get(axum::http::header::AUTHORIZATION) {
         let header_str = auth_header.to_str()?;
-        let client_id = Jwt(header_str.to_string()).decode(&AUD)?;
+        let client_id = Jwt(header_str.to_string()).decode(&HashSet::from([aud.to_string()]))?;
         Ok(check(Some(client_id)))
     } else {
         // Note: Authentication is not required right now to ensure that this is a

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,6 +1,11 @@
 use {
-    axum::{response::IntoResponse, Json},
+    crate::{
+        authentication::Jwt,
+        error::{Error::InvalidAuthentication, Result},
+    },
+    axum::{http::HeaderMap, response::IntoResponse, Json},
     hyper::StatusCode,
+    relay_rpc::domain::ClientId,
     serde_json::{json, Value},
 };
 
@@ -19,6 +24,22 @@ pub mod update_apns;
 pub mod update_fcm;
 
 pub const DECENTRALIZED_IDENTIFIER_PREFIX: &str = "did:key:";
+
+pub fn authenticate_client(
+    headers: HeaderMap,
+    check: fn(Option<ClientId>) -> bool,
+) -> Result<bool> {
+    return if let Some(auth_header) = headers.get(axum::http::header::AUTHORIZATION) {
+        let header_str = auth_header.to_str()?;
+        let client_id = Jwt(header_str.to_string()).decode(&AUD)?;
+        Ok(check(Some(client_id)))
+    } else {
+        // Note: Authentication is not required right now to ensure that this is a
+        // non-breaking change, eventually it will be required and this should default
+        // to returning `Err(MissingAuthentication)` or `Err(InvalidAuthentication)`
+        Ok(true)
+    };
+}
 
 #[derive(serde::Serialize)]
 #[serde(rename_all = "lowercase")]

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -28,9 +28,7 @@ where
     F: FnOnce(Option<ClientId>) -> bool,
 {
     return if let Some(auth_header) = headers.get(axum::http::header::AUTHORIZATION) {
-        // TODO: fix unwrap
-        let header_str = auth_header.to_str().unwrap();
-        // let header_str = auth_header.to_str()?;
+        let header_str = auth_header.to_str()?;
         let client_id = Jwt(header_str.to_string()).decode(&HashSet::from([aud.to_string()]))?;
         Ok(check(Some(client_id)))
     } else {

--- a/src/handlers/register_client.rs
+++ b/src/handlers/register_client.rs
@@ -35,7 +35,7 @@ pub async fn handler(
     Json(body): Json<RegisterBody>,
     headers: HeaderMap,
 ) -> Result<Response> {
-    if !authenticate_client(headers, |client_id| {
+    if !authenticate_client(headers, &state.config.public_url, |client_id| {
         if let Some(client_id) = client_id {
             &client_id == &body.client_id
         } else {

--- a/src/handlers/register_client.rs
+++ b/src/handlers/register_client.rs
@@ -1,23 +1,29 @@
 use {
     crate::{
+        authentication::Jwt,
         error::{
-            Error::{EmptyField, ProviderNotAvailable},
+            Error::{EmptyField, InvalidAuthentication, ProviderNotAvailable},
             Result,
         },
-        handlers::{Response, DECENTRALIZED_IDENTIFIER_PREFIX},
+        handlers::{authenticate_client, Response, DECENTRALIZED_IDENTIFIER_PREFIX},
         increment_counter,
         log::prelude::*,
         state::AppState,
         stores::client::Client,
     },
-    axum::extract::{Json, Path, State as StateExtractor},
+    axum::{
+        extract::{Json, Path, State as StateExtractor},
+        http::HeaderMap,
+    },
+    hyper::header::AUTHORIZATION,
+    relay_rpc::domain::ClientId,
     serde::{Deserialize, Serialize},
-    std::sync::Arc,
+    std::{collections::HashSet, sync::Arc},
 };
 
 #[derive(Serialize, Deserialize)]
 pub struct RegisterBody {
-    pub client_id: String,
+    pub client_id: ClientId,
     #[serde(rename = "type")]
     pub push_type: String,
     pub token: String,
@@ -27,7 +33,18 @@ pub async fn handler(
     Path(tenant_id): Path<String>,
     StateExtractor(state): StateExtractor<Arc<AppState>>,
     Json(body): Json<RegisterBody>,
+    headers: HeaderMap,
 ) -> Result<Response> {
+    if !authenticate_client(headers, |client_id| {
+        if let Some(client_id) = client_id {
+            &client_id == &body.client_id
+        } else {
+            false
+        }
+    })? {
+        return Err(InvalidAuthentication);
+    }
+
     let push_type = body.push_type.as_str().try_into()?;
     let tenant = state.tenant_store.get_tenant(&tenant_id).await?;
     let supported_providers = tenant.providers();

--- a/src/handlers/single_tenant_wrappers.rs
+++ b/src/handlers/single_tenant_wrappers.rs
@@ -17,7 +17,6 @@ pub async fn delete_handler(
     Path(id): Path<String>,
     state: StateExtractor<Arc<AppState>>,
     headers: HeaderMap,
-    body: Json<RegisterBody>,
 ) -> Result<Response> {
     if state.is_multitenant() {
         return Err(MissingTenantId);
@@ -27,7 +26,6 @@ pub async fn delete_handler(
         Path((state.config.default_tenant_id.clone(), id)),
         state,
         headers,
-        body,
     )
     .await
 }

--- a/src/handlers/single_tenant_wrappers.rs
+++ b/src/handlers/single_tenant_wrappers.rs
@@ -9,12 +9,15 @@ use {
         extract::{Path, State as StateExtractor},
         Json,
     },
+    hyper::HeaderMap,
     std::sync::Arc,
 };
 
 pub async fn delete_handler(
     Path(id): Path<String>,
     state: StateExtractor<Arc<AppState>>,
+    headers: HeaderMap,
+    body: Json<RegisterBody>,
 ) -> Result<Response> {
     if state.is_multitenant() {
         return Err(MissingTenantId);
@@ -23,6 +26,8 @@ pub async fn delete_handler(
     crate::handlers::delete_client::handler(
         Path((state.config.default_tenant_id.clone(), id)),
         state,
+        headers,
+        body,
     )
     .await
 }
@@ -46,6 +51,7 @@ pub async fn push_handler(
 
 pub async fn register_handler(
     state: StateExtractor<Arc<AppState>>,
+    headers: HeaderMap,
     body: Json<RegisterBody>,
 ) -> Result<Response> {
     if state.is_multitenant() {
@@ -55,6 +61,7 @@ pub async fn register_handler(
     crate::handlers::register_client::handler(
         Path(state.config.default_tenant_id.clone()),
         state,
+        headers,
         body,
     )
     .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use {
     tracing::{info, log::LevelFilter, warn, Level},
 };
 
+pub mod authentication;
 pub mod blob;
 pub mod config;
 pub mod error;

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -142,6 +142,8 @@ module "ecs" {
   aws_otel_collector_ecr_repository_url = data.aws_ecr_repository.aws_otel_collector.repository_url
 }
 
+
+
 module "monitoring" {
   source = "./monitoring"
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,7 +10,7 @@ variable "azs" {
 
 variable "public_url" {
   type    = string
-  default = "https://echo.walletconnect.com"
+  default = "echo.walletconnect.com"
 }
 
 variable "grafana_endpoint" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,7 +10,7 @@ variable "azs" {
 
 variable "public_url" {
   type    = string
-  default = "echo.walletconnect.com"
+  default = "https://echo.walletconnect.com"
 }
 
 variable "grafana_endpoint" {

--- a/tests/functional/push.rs
+++ b/tests/functional/push.rs
@@ -15,7 +15,7 @@ use {
 #[tokio::test]
 async fn test_push(ctx: &mut SingleTenantServerContext) {
     let charset = "1234567890";
-    let random_client_id = ClientId(Arc::from(generate(12, charset)));
+    let random_client_id = ClientId::new(Arc::from(generate(12, charset)));
     let payload = RegisterBody {
         client_id: random_client_id.clone(),
         push_type: "noop".to_string(),

--- a/tests/functional/push.rs
+++ b/tests/functional/push.rs
@@ -5,6 +5,8 @@ use {
         register_client::RegisterBody,
     },
     random_string::generate,
+    relay_rpc::domain::ClientId,
+    std::sync::Arc,
     test_context::test_context,
     uuid::Uuid,
 };
@@ -13,7 +15,7 @@ use {
 #[tokio::test]
 async fn test_push(ctx: &mut SingleTenantServerContext) {
     let charset = "1234567890";
-    let random_client_id = generate(12, charset);
+    let random_client_id = ClientId(Arc::from(generate(12, charset)));
     let payload = RegisterBody {
         client_id: random_client_id.clone(),
         push_type: "noop".to_string(),

--- a/tests/functional/registration.rs
+++ b/tests/functional/registration.rs
@@ -32,7 +32,10 @@ async fn test_registration(ctx: &mut SingleTenantServerContext) {
     let mut seeded = StdRng::from_seed(seed);
     let keypair = Keypair::generate(&mut seeded);
 
+    dbg!(ctx.server.public_addr.to_string());
+
     let jwt = relay_rpc::auth::AuthToken::new(random_client_id.value().clone())
+        .aud(format!("127.0.0.1:{}", ctx.server.public_addr.port()))
         .as_jwt(&keypair)
         .unwrap()
         .to_string();
@@ -44,8 +47,9 @@ async fn test_registration(ctx: &mut SingleTenantServerContext) {
         .header("Authorization", jwt)
         .json(&payload)
         .send()
-        .await
-        .expect("Call failed");
+        .await;
+    dbg!(&response);
+    let response = response.expect("Call failed");
 
     assert!(
         response.status().is_success(),

--- a/tests/functional/registration.rs
+++ b/tests/functional/registration.rs
@@ -2,6 +2,8 @@ use {
     crate::context::SingleTenantServerContext,
     echo_server::handlers::register_client::RegisterBody,
     random_string::generate,
+    relay_rpc::domain::ClientId,
+    std::sync::Arc,
     test_context::test_context,
 };
 
@@ -9,7 +11,7 @@ use {
 #[tokio::test]
 async fn test_registration(ctx: &mut SingleTenantServerContext) {
     let charset = "1234567890";
-    let random_client_id = generate(12, charset);
+    let random_client_id = ClientId(Arc::from(generate(12, charset)));
     let payload = RegisterBody {
         client_id: random_client_id.clone(),
         push_type: "noop".to_string(),
@@ -53,7 +55,7 @@ async fn test_registration(ctx: &mut SingleTenantServerContext) {
 #[tokio::test]
 async fn test_deregistration(ctx: &mut SingleTenantServerContext) {
     let charset = "1234567890";
-    let random_client_id = generate(12, charset);
+    let random_client_id = ClientId(Arc::from(generate(12, charset)));
     let payload = RegisterBody {
         client_id: random_client_id.clone(),
         push_type: "noop".to_string(),

--- a/tests/functional/registration.rs
+++ b/tests/functional/registration.rs
@@ -85,10 +85,9 @@ async fn test_deregistration(ctx: &mut SingleTenantServerContext) {
         .await
         .expect("Call failed");
 
-    dbg!(&delete_response);
+    let status = delete_response.status().clone();
 
-    assert!(
-        delete_response.status().is_success(),
-        "Failed to unregister client"
-    );
+    dbg!(&delete_response.text().await.unwrap());
+
+    assert!(status.is_success(), "Failed to unregister client");
 }

--- a/tests/functional/registration.rs
+++ b/tests/functional/registration.rs
@@ -11,7 +11,7 @@ use {
 #[tokio::test]
 async fn test_registration(ctx: &mut SingleTenantServerContext) {
     let charset = "1234567890";
-    let random_client_id = ClientId(Arc::from(generate(12, charset)));
+    let random_client_id = ClientId::new(Arc::from(generate(12, charset)));
     let payload = RegisterBody {
         client_id: random_client_id.clone(),
         push_type: "noop".to_string(),
@@ -55,7 +55,7 @@ async fn test_registration(ctx: &mut SingleTenantServerContext) {
 #[tokio::test]
 async fn test_deregistration(ctx: &mut SingleTenantServerContext) {
     let charset = "1234567890";
-    let random_client_id = ClientId(Arc::from(generate(12, charset)));
+    let random_client_id = ClientId::new(Arc::from(generate(12, charset)));
     let payload = RegisterBody {
         client_id: random_client_id.clone(),
         push_type: "noop".to_string(),
@@ -84,6 +84,8 @@ async fn test_deregistration(ctx: &mut SingleTenantServerContext) {
         .send()
         .await
         .expect("Call failed");
+
+    dbg!(&delete_response);
 
     assert!(
         delete_response.status().is_success(),


### PR DESCRIPTION
# Description
Adds non-breaking client id/jwt validation on the client endpoints

## How Has This Been Tested?
N/a, non-breaking so will do integration testing with SDK teams once they have upgraded

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update