### PR TITLE
fix: Update ed25519-dalek to 2.0.0-rc.2 and resolve breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,6 +677,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +909,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+
+[[package]]
 name = "const-random"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,13 +1057,28 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d928d978dbec61a1167414f5ec534f24bea0d7a0d24dd9b6233d3d8223e585"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.6",
+ "fiat-crypto",
+ "packed_simd_2",
+ "platforms",
  "subtle",
  "zeroize",
 ]
@@ -1118,6 +1145,16 @@ name = "data-encoding"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
+
+[[package]]
+name = "der"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b10af9f9f9f2134a42d3f8aa74658660f2e0234b0eb81bd171df8aa32779ed"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
 
 [[package]]
 name = "derive_more"
@@ -1206,7 +1243,7 @@ dependencies = [
  "chrono",
  "data-encoding",
  "dotenv",
- "ed25519-dalek 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 2.0.0-rc.2",
  "envy",
  "fcm",
  "futures-util",
@@ -1248,17 +1285,26 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "signature",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb04eee5d9d907f29e80ee6b0e78f7e2c82342c63e3580d8c4f69d9d5aad963"
+dependencies = [
+ "pkcs8",
+ "signature 2.1.0",
 ]
 
 [[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+source = "git+https://github.com/dalek-cryptography/ed25519-dalek.git?rev=7529d65#7529d65506147b6cb24ca6d8f4fc062cac33b395"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 3.2.0",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
@@ -1267,14 +1313,14 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.1"
-source = "git+https://github.com/dalek-cryptography/ed25519-dalek.git?rev=7529d65#7529d65506147b6cb24ca6d8f4fc062cac33b395"
+version = "2.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "798f704d128510932661a3489b08e3f4c934a01d61c5def59ae7b8e48f19665a"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand 0.7.3",
+ "curve25519-dalek 4.0.0-rc.2",
+ "ed25519 2.2.1",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "zeroize",
 ]
 
@@ -1372,6 +1418,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "fixedbitset"
@@ -2046,6 +2098,12 @@ dependencies = [
 
 [[package]]
 name = "libm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+
+[[package]]
+name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
@@ -2364,7 +2422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
- "libm",
+ "libm 0.2.6",
 ]
 
 [[package]]
@@ -2556,6 +2614,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "packed_simd_2"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
+dependencies = [
+ "cfg-if",
+ "libm 0.1.4",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,10 +2769,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "platforms"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "pnet_base"
@@ -3024,7 +3108,7 @@ dependencies = [
  "chrono",
  "data-encoding",
  "derive_more",
- "ed25519-dalek 1.0.1 (git+https://github.com/dalek-cryptography/ed25519-dalek.git?rev=7529d65)",
+ "ed25519-dalek 1.0.1",
  "jsonwebtoken",
  "once_cell",
  "rand 0.7.3",
@@ -3380,6 +3464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3433,6 +3523,16 @@ name = "spin"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34"
+
+[[package]]
+name = "spki"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "sqlformat"
@@ -3576,18 +3676,6 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
 
 [[package]]
 name = "tempfile"
@@ -4063,12 +4151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4418,24 +4500,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ a2 = { git = "https://github.com/WalletConnect/a2", rev = "d0236c3", features = 
 fcm = "0.9"
 
 # Signature validation
-ed25519-dalek = "1.0"
+ed25519-dalek = "2.0.0-rc.2"
 
 # JWT Authentication
 relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "ced99e7"}

--- a/src/middleware/validate_signature.rs
+++ b/src/middleware/validate_signature.rs
@@ -11,7 +11,7 @@ use {
     },
     async_trait::async_trait,
     axum::{body, extract::FromRequest, http::Request},
-    ed25519_dalek::{PublicKey, Signature, Verifier},
+    ed25519_dalek::{ed25519::SignatureBytes, Signature, Verifier, VerifyingKey},
     tracing::span,
 };
 
@@ -84,12 +84,12 @@ pub async fn signature_is_valid(
     signature: &str,
     timestamp: &str,
     body: &str,
-    public_key: &PublicKey,
+    public_key: &VerifyingKey,
 ) -> Result<bool, crate::error::Error> {
     let sig_body = format!("{}.{}.{}", timestamp, body.len(), body);
 
     let sig_bytes = hex::decode(signature)?;
-    let sig = Signature::from_bytes(&sig_bytes)?;
+    let sig = Signature::from_bytes(<&SignatureBytes>::try_from(sig_bytes.as_slice()).unwrap());
 
     Ok(public_key.verify(sig_body.as_bytes(), &sig).is_ok())
 }

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -51,7 +51,8 @@ impl RelayClient {
             .await?;
         let body = response.text().await?;
         let key_bytes = hex::decode(body)?;
-        let public_key = VerifyingKey::from_bytes(<&[u8; 32]>::try_from(key_bytes.as_slice()).unwrap())?;
+        let public_key =
+            VerifyingKey::from_bytes(<&[u8; 32]>::try_from(key_bytes.as_slice()).unwrap())?;
         Ok(public_key)
     }
 

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -1,6 +1,6 @@
 use {
     chrono::{DateTime, Duration, Utc},
-    ed25519_dalek::PublicKey,
+    ed25519_dalek::VerifyingKey,
     std::ops::Add,
 };
 
@@ -10,7 +10,7 @@ const PUBLIC_KEY_TTL_HOURS: i64 = 6;
 pub struct RelayClient {
     http_client: reqwest::Client,
     base_url: String,
-    public_key: Option<PublicKey>,
+    public_key: Option<VerifyingKey>,
     public_key_last_fetched: DateTime<Utc>,
 }
 
@@ -25,7 +25,7 @@ impl RelayClient {
     }
 
     /// Fetches the public key with a TTL
-    pub async fn public_key(&mut self) -> crate::error::Result<PublicKey> {
+    pub async fn public_key(&mut self) -> crate::error::Result<VerifyingKey> {
         if let Some(public_key) = self.public_key {
             // TTL Not exceeded
             if self
@@ -43,7 +43,7 @@ impl RelayClient {
         Ok(public_key)
     }
 
-    async fn fetch_public_key(&self) -> crate::error::Result<PublicKey> {
+    async fn fetch_public_key(&self) -> crate::error::Result<VerifyingKey> {
         let response = self
             .http_client
             .get(self.get_url("public-key"))
@@ -51,7 +51,7 @@ impl RelayClient {
             .await?;
         let body = response.text().await?;
         let key_bytes = hex::decode(body)?;
-        let public_key = PublicKey::from_bytes(&key_bytes)?;
+        let public_key = VerifyingKey::from_bytes(<&[u8; 32]>::try_from(key_bytes.as_slice()).unwrap())?;
         Ok(public_key)
     }
 


### PR DESCRIPTION
# Description

This fixes a dependency conflict with `zeroize` that you will likely encounter in the future. Feel free to table this PR since this is a change to a cryptographic library until you need it/can vet, but we need it downstream because we are relying on `sqlx 0.7.0-alpha.1` which provides a way for us to refresh the token provided to the connection pool for our AWS RDS IAM authentication usage.

The following dependency conflict will be encountered if you try to upgrade to `sqlx 0.7.0-alpha.1`. This stems from https://github.com/dalek-cryptography/curve25519-dalek/issues/362 which binds `zeroize` to `<1.4` due to requiring `rust 1.51+`. Resolving this requires upgrading `ed25519-dalek` to `2.0.0-pre.0` which has these breaking changes: https://github.com/dalek-cryptography/ed25519-dalek#breaking-changes-in-200. We should be fine with the MSRV change to `1.60` as the image is currently using `rust 1.67`.

```
error: failed to select a version for `zeroize`.
    ... required by package `num-bigint-dig v0.8.2`
    ... which satisfies dependency `num-bigint = "^0.8.2"` of package `rsa v0.8.0`
    ... which satisfies dependency `rsa = "^0.8.0"` of package `sqlx-mysql v0.7.0-alpha.1 (https://github.com/launchbadge/sqlx.git?rev=c17c59fc4c13d5031f05b316ef8a8fb44875a822#c17c59fc)`
    ... which satisfies git dependency `sqlx-mysql` of package `sqlx v0.7.0-alpha.1 (https://github.com/launchbadge/sqlx.git?rev=c17c59fc4c13d5031f05b316ef8a8fb44875a822#c17c59fc)`
    ... which satisfies git dependency `sqlx` of package `echo-server v0.19.3 (/home/wcheng/dev/rust/echo-server)`
versions that meet the requirements `^1.5` are: 1.5.7, 1.5.6, 1.5.5, 1.5.4, 1.5.3

all possible versions conflict with previously selected packages.

  previously selected package `zeroize v1.3.0`
    ... which satisfies dependency `zeroize = ">=1, <1.4"` (locked to 1.3.0) of package `curve25519-dalek v3.2.1`
    ... which satisfies dependency `curve25519-dalek = "^3"` (locked to 3.2.1) of package `ed25519-dalek v1.0.1`
    ... which satisfies dependency `ed25519-dalek = "^1.0"` (locked to 1.0.1) of package `echo-server v0.19.3 (/home/wcheng/dev/rust/echo-server)`

failed to select a version for `zeroize` which could resolve this conflict
```



## How Has This Been Tested?

Tests pass and this is currently running downstream in prod with no issues.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update