### PR TITLE
fix: have `/health` and `/info` endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,7 +1251,7 @@ checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 
 [[package]]
 name = "echo-server"
-version = "0.23.6"
+version = "0.24.0"
 dependencies = [
  "a2",
  "async-trait",

--- a/src/handlers/health.rs
+++ b/src/handlers/health.rs
@@ -1,48 +1,12 @@
 use {
-    crate::{
-        request_id::get_req_id,
-        state::{AppState, State},
-    },
-    axum::{
-        extract::State as ExtractState,
-        http::{HeaderMap, StatusCode},
-        response::IntoResponse,
-        Json,
-    },
-    serde::Serialize,
+    crate::state::AppState,
+    axum::{extract::State as ExtractState, http::StatusCode, response::IntoResponse},
     std::sync::Arc,
 };
 
-#[derive(Serialize)]
-struct HealthResponseFlags {
-    pub multitenant: bool,
-    pub metrics: bool,
-}
-
-#[derive(Serialize)]
-struct HealthResponse {
-    pub status: String,
-    pub version: String,
-    pub flags: HealthResponseFlags,
-    pub features_enabled: Vec<String>,
-    pub request_id: String,
-}
-
-pub async fn handler(
-    ExtractState(state): ExtractState<Arc<AppState>>,
-    headers: HeaderMap,
-) -> impl IntoResponse {
+pub async fn handler(ExtractState(state): ExtractState<Arc<AppState>>) -> impl IntoResponse {
     (
         StatusCode::OK,
-        Json(HealthResponse {
-            status: "OK".to_string(),
-            version: state.build_info.crate_info.version.to_string(),
-            flags: HealthResponseFlags {
-                multitenant: state.is_multitenant(),
-                metrics: state.metrics.is_some(),
-            },
-            features_enabled: state.build_info.crate_info.enabled_features.clone(),
-            request_id: get_req_id(&headers),
-        }),
+        format!("OK, echo-server v{}", state.build_info.crate_info.version,),
     )
 }

--- a/src/handlers/info.rs
+++ b/src/handlers/info.rs
@@ -1,0 +1,48 @@
+use {
+    crate::{
+        request_id::get_req_id,
+        state::{AppState, State},
+    },
+    axum::{
+        extract::State as ExtractState,
+        http::{HeaderMap, StatusCode},
+        response::IntoResponse,
+        Json,
+    },
+    serde::Serialize,
+    std::sync::Arc,
+};
+
+#[derive(Serialize)]
+struct HealthResponseFlags {
+    pub multitenant: bool,
+    pub metrics: bool,
+}
+
+#[derive(Serialize)]
+struct HealthResponse {
+    pub status: String,
+    pub version: String,
+    pub flags: HealthResponseFlags,
+    pub features_enabled: Vec<String>,
+    pub request_id: String,
+}
+
+pub async fn handler(
+    ExtractState(state): ExtractState<Arc<AppState>>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        Json(HealthResponse {
+            status: "OK".to_string(),
+            version: state.build_info.crate_info.version.to_string(),
+            flags: HealthResponseFlags {
+                multitenant: state.is_multitenant(),
+                metrics: state.metrics.is_some(),
+            },
+            features_enabled: state.build_info.crate_info.enabled_features.clone(),
+            request_id: get_req_id(&headers),
+        }),
+    )
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -10,7 +10,7 @@ use {
 
 // Push
 pub mod delete_client;
-pub mod health;
+pub mod info;
 pub mod metrics;
 pub mod push_message;
 pub mod register_client;
@@ -23,6 +23,7 @@ pub mod create_tenant;
 pub mod delete_tenant;
 #[cfg(feature = "multitenant")]
 pub mod get_tenant;
+pub mod health;
 #[cfg(feature = "multitenant")]
 pub mod update_apns;
 #[cfg(feature = "multitenant")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,7 @@ pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Config) -> 
 
         Router::new()
             .route("/health", get(handlers::health::handler))
+            .route("/info", get(handlers::info::handler))
             .nest("/tenants", tenancy_routes)
             .route(
                 "/:tenant_id/clients",
@@ -217,6 +218,7 @@ pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Config) -> 
     #[cfg(not(feature = "multitenant"))]
     let app = Router::new()
         .route("/health", get(handlers::health::handler))
+        .route("/info", get(handlers::info::handler))
         .route(
             "/clients",
             post(handlers::single_tenant_wrappers::register_handler),


### PR DESCRIPTION
# Description
Allows Cloudflare health checks to be resolved

## How Has This Been Tested?
Tested locally

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update