### PR TITLE
fix(o11y): received notifications metric broken

### DIFF
--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -117,11 +117,33 @@ resource "grafana_dashboard" "at_a_glance" {
               "type" : "prometheus",
               "uid" : grafana_data_source.prometheus.uid
             },
-            "exemplar" : true,
             "expr" : "sum(rate(received_notifications{}[1h]))",
-            "interval" : "",
-            "legendFormat" : "",
-            "refId" : "A"
+            "legendFormat" : "__auto",
+            "refId" : "Received"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": grafana_data_source.prometheus.uid
+            },
+            "editorMode": "code",
+            "expr": "sum(increase(sent_apns_notifications{}[1h]))",
+            "hide": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "SentAPNS"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": grafana_data_source.prometheus.uid
+            },
+            "editorMode": "code",
+            "expr": "sum(increase(sent_fcm_notifications{}[1h]))",
+            "hide": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "SentFCM"
           }
         ],
         "title" : "Notifications per Hour",
@@ -305,23 +327,11 @@ resource "grafana_dashboard" "at_a_glance" {
               "uid" : grafana_data_source.prometheus.uid
             },
             "exemplar" : true,
-            "expr" : "sum(received_notifications{})",
+            "expr" : "sum(increase(received_notifications{}[1h]))",
             "format" : "time_series",
             "interval" : "",
             "legendFormat" : "",
             "refId" : "Notifications"
-          },
-          {
-            "datasource" : {
-              "type" : "prometheus",
-              "uid" : "S5BhqwK4z"
-            },
-            "exemplar" : true,
-            "expr" : "",
-            "hide" : false,
-            "interval" : "",
-            "legendFormat" : "",
-            "refId" : "Processed Notifications"
           }
         ],
         "title" : "Received Notifications",

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -122,28 +122,28 @@ resource "grafana_dashboard" "at_a_glance" {
             "refId" : "Received"
           },
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": grafana_data_source.prometheus.uid
+            "datasource" : {
+              "type" : "prometheus",
+              "uid" : grafana_data_source.prometheus.uid
             },
-            "editorMode": "code",
-            "expr": "sum(increase(sent_apns_notifications{}[1h]))",
-            "hide": false,
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "SentAPNS"
+            "editorMode" : "code",
+            "expr" : "sum(increase(sent_apns_notifications{}[1h]))",
+            "hide" : false,
+            "legendFormat" : "__auto",
+            "range" : true,
+            "refId" : "SentAPNS"
           },
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": grafana_data_source.prometheus.uid
+            "datasource" : {
+              "type" : "prometheus",
+              "uid" : grafana_data_source.prometheus.uid
             },
-            "editorMode": "code",
-            "expr": "sum(increase(sent_fcm_notifications{}[1h]))",
-            "hide": false,
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "SentFCM"
+            "editorMode" : "code",
+            "expr" : "sum(increase(sent_fcm_notifications{}[1h]))",
+            "hide" : false,
+            "legendFormat" : "__auto",
+            "range" : true,
+            "refId" : "SentFCM"
           }
         ],
         "title" : "Notifications per Hour",


### PR DESCRIPTION
# Description

Wasn't using `increase`. Also was hardcoding datasource hence broken either in staging or prod.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update