### PR TITLE
fix: return correct error code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,7 +1100,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "echo-server"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "a2",
  "async-recursion",

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,8 +31,8 @@ pub enum Error {
     #[error(transparent)]
     Apns(#[from] a2::Error),
 
-    #[error(transparent)]
-    ApnsResponse(#[from] a2::ErrorReason),
+    #[error("APNS Responded with error, {0}")]
+    ApnsResponse(a2::ErrorReason),
 
     #[error(transparent)]
     Fcm(#[from] fcm::FcmError),

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,8 +25,14 @@ pub enum Error {
     #[error(transparent)]
     Prometheus(#[from] prometheus_core::Error),
 
+    #[error("invalid device token provided")]
+    BadDeviceToken,
+
     #[error(transparent)]
     Apns(#[from] a2::Error),
+
+    #[error(transparent)]
+    ApnsResponse(#[from] a2::ErrorReason),
 
     #[error(transparent)]
     Fcm(#[from] fcm::FcmError),
@@ -162,9 +168,27 @@ impl IntoResponse for Error {
     fn into_response(self) -> Response {
         error!("responding with error ({:?})", self);
         match self {
+            Error::BadDeviceToken => crate::handlers::Response::new_failure(StatusCode::BAD_REQUEST, vec![
+                ResponseError {
+                    name: "invalid_token".to_string(),
+                    message: "Provided device token is now invalid, the client id has been un-registered".to_string(),
+                }
+            ], vec![
+                ErrorField {
+                    field: "token".to_string(),
+                    description: "Invalid device token".to_string(),
+                    location: ErrorLocation::Body,
+                }
+            ]),
             Error::Apns(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
                 ResponseError {
                     name: "apns".to_string(),
+                    message: e.to_string(),
+                }
+            ], vec![]),
+            Error::ApnsResponse(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
+                ResponseError {
+                    name: "apns_response".to_string(),
                     message: e.to_string(),
                 }
             ], vec![]),

--- a/src/providers/apns.rs
+++ b/src/providers/apns.rs
@@ -69,12 +69,13 @@ impl PushProvider for ApnsProvider {
         };
 
         // TODO tidy after https://github.com/WalletConnect/a2/issues/67 is closed
-        if payload.is_encrypted() {
-            let mut notification_payload = a2::DefaultNotificationBuilder::new()
-                .set_content_available()
-                .set_mutable_content()
-                .set_title("You have new notifications. Open to view")
-                .build(token.as_str(), opt);
+        let _res = match payload.is_encrypted() {
+            true => {
+                let mut notification_payload = a2::DefaultNotificationBuilder::new()
+                    .set_content_available()
+                    .set_mutable_content()
+                    .set_title("You have new notifications. Open to view")
+                    .build(token.as_str(), opt);
 
                 notification_payload.add_custom_data("topic", &payload.topic)?;
                 notification_payload.add_custom_data("blob", &payload.blob)?;

--- a/src/providers/apns.rs
+++ b/src/providers/apns.rs
@@ -69,7 +69,7 @@ impl PushProvider for ApnsProvider {
         };
 
         // TODO tidy after https://github.com/WalletConnect/a2/issues/67 is closed
-        let _res = match payload.is_encrypted() {
+        let result = match payload.is_encrypted() {
             true => {
                 let mut notification_payload = a2::DefaultNotificationBuilder::new()
                     .set_content_available()


### PR DESCRIPTION
# Description
Returns the correct error code when device tokens have expired or are invalid for APNS, requires a follow-up PR to delete clients from the database

Resolves #147 

## How Has This Been Tested?
Responses should improve in relay logs, non-breaking

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update