### PR TITLE
feat: add `msg_id` to analytics exports

### DIFF
--- a/src/analytics/message_info.rs
+++ b/src/analytics/message_info.rs
@@ -3,6 +3,7 @@ use {parquet_derive::ParquetRecordWriter, serde::Serialize, std::sync::Arc};
 #[derive(Debug, Clone, Serialize, ParquetRecordWriter)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageInfo {
+    pub msg_id: Arc<str>,
     pub region: Option<Arc<str>>,
     pub country: Option<Arc<str>>,
     pub continent: Option<Arc<str>>,

--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -183,6 +183,7 @@ pub async fn handler(
             );
 
             let msg = MessageInfo {
+                msg_id: body.id.into(),
                 region: region.map(|r| Arc::from(r.join(", "))),
                 country,
                 continent,


### PR DESCRIPTION
# Description

Add the message id (`PushMessageBody.id`) to analytics exports

Resolves #152 

## How Has This Been Tested?

No tests yet

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update