### PR TITLE
fix: catch panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,7 +1100,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "echo-server"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "a2",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cloud = []
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.6", features = ["json", "multipart", "tokio"] }
 tower = "0.4"
-tower-http = { version = "0.4", features = ["trace", "cors", "request-id", "propagate-header"] }
+tower-http = { version = "0.4", features = ["trace", "cors", "request-id", "propagate-header", "catch-panic"] }
 hyper = "0.14"
 
 # Database

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use tower_http::catch_panic::CatchPanicLayer;
 use {
     crate::{
         log::prelude::*,
@@ -172,7 +173,8 @@ pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Config) -> 
                         .include_headers(true),
                 ),
         )
-        .layer(PropagateRequestIdLayer::new(X_REQUEST_ID.clone()));
+        .layer(PropagateRequestIdLayer::new(X_REQUEST_ID.clone()))
+        .layer(CatchPanicLayer::new());
 
     #[cfg(feature = "multitenant")]
     let app = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use tower_http::catch_panic::CatchPanicLayer;
 use {
     crate::{
         log::prelude::*,
@@ -19,6 +18,7 @@ use {
     tokio::{select, sync::broadcast},
     tower::ServiceBuilder,
     tower_http::{
+        catch_panic::CatchPanicLayer,
         request_id::{PropagateRequestIdLayer, SetRequestIdLayer},
         trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer},
     },


### PR DESCRIPTION
# Description

Catches panics, meaning if middleware panics it will not be logged and a proper 5XX will be responded with. This dosen't fully rectify the 5XX issue but will allow us to identify which service/middleware is causing this.

## How Has This Been Tested?
Builds locally & Actions

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update