### PR TITLE
fix: ensure tenant_id matches the tenant a client is registered with

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -164,7 +164,7 @@ pub enum Error {
     GeoIpS3Failed,
 
     #[error("tenant id and client's registered tenant didn't match")]
-    MissatchedTenantId,
+    MissmatchedTenantId,
 }
 
 impl IntoResponse for Error {
@@ -484,7 +484,7 @@ impl IntoResponse for Error {
                     message: "JWT Authentication Failed".to_string(),
                 },
             ], vec![]),
-            Error::MissatchedTenantId => crate::handlers::Response::new_failure(StatusCode::BAD_REQUEST, vec![
+            Error::MissmatchedTenantId => crate::handlers::Response::new_failure(StatusCode::BAD_REQUEST, vec![
                 ResponseError {
                     name: "missmatched_identifiers".to_string(),
                     message: "The requested tenant doesn't have this client registered".to_string(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -162,6 +162,9 @@ pub enum Error {
 
     #[error("failed to load geoip database from s3")]
     GeoIpS3Failed,
+
+    #[error("tenant id and client's registered tenant didn't match")]
+    MissatchedTenantId,
 }
 
 impl IntoResponse for Error {
@@ -481,6 +484,23 @@ impl IntoResponse for Error {
                     message: "JWT Authentication Failed".to_string(),
                 },
             ], vec![]),
+            Error::MissatchedTenantId => crate::handlers::Response::new_failure(StatusCode::BAD_REQUEST, vec![
+                ResponseError {
+                    name: "missmatched_identifiers".to_string(),
+                    message: "The requested tenant doesn't have this client registered".to_string(),
+                },
+            ], vec![
+                ErrorField {
+                    field: "tenant_id".to_string(),
+                    description: "doesn't match registered id".to_string(),
+                    location: ErrorLocation::Path,
+                },
+                ErrorField {
+                    field: "id".to_string(),
+                    description: "doesn't match registered id".to_string(),
+                    location: ErrorLocation::Path,
+                }
+            ]),
             e => {
                 warn!("Error does not have response clause, {:?}", e);
 

--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -35,7 +35,7 @@ pub struct MessagePayload {
 
 impl MessagePayload {
     pub fn is_encrypted(&self) -> bool {
-        (self.flags.clone() & ENCRYPTED_FLAG) == ENCRYPTED_FLAG
+        (self.flags & ENCRYPTED_FLAG) == ENCRYPTED_FLAG
     }
 }
 

--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -35,7 +35,7 @@ pub struct MessagePayload {
 
 impl MessagePayload {
     pub fn is_encrypted(&self) -> bool {
-        (self.flags & ENCRYPTED_FLAG) == ENCRYPTED_FLAG
+        (self.flags.clone() & ENCRYPTED_FLAG) == ENCRYPTED_FLAG
     }
 }
 
@@ -60,9 +60,10 @@ pub async fn handler(
     )
     .await;
 
+    #[cfg(feature = "analytics")]
     let request_id = get_req_id(&headers);
 
-    let (status, response, analytics_option) = match res {
+    let inner_packed = match res {
         Ok((res, analytics_options_inner)) => (res.status().as_u16(), res, analytics_options_inner),
         Err((error, analytics_option_inner)) => {
             #[cfg(feature = "analytics")]
@@ -89,6 +90,12 @@ pub async fn handler(
             (status_code, res, analytics_option)
         }
     };
+
+    #[cfg(feature = "analytics")]
+    let (status, response, analytics_option) = inner_packed;
+
+    #[cfg(not(feature = "analytics"))]
+    let (_status, response, _analytics_option) = inner_packed;
 
     #[cfg(feature = "analytics")]
     if let Some(mut message_info) = analytics_option {
@@ -159,8 +166,8 @@ pub async fn handler_internal(
                 client_id: id.clone().into(),
                 topic: topic.clone(),
                 push_provider: "unknown".into(),
-                encrypted,
-                flags,
+                encrypted: encrypted.clone(),
+                flags: flags.clone(),
                 status: 0,
                 response_message: None,
                 received_at: gorgon::time::now(),
@@ -213,19 +220,49 @@ pub async fn handler_internal(
             "client tenant id does not match request tenant id"
         );
 
-        #[cfg(feature = "analytics")]
+        #[cfg(feature = "multitenant")]
         {
-            analytics = Some(MessageInfo {
-                response_message: Some("Client tenant id does not match request tenant id".into()),
-                ..analytics.unwrap()
-            });
+            if client.tenant_id == "0000-0000-0000-0000" {
+                warn!(
+                    %request_id,
+                    %tenant_id,
+                    client_id = %id,
+                    "client tenant id has not been set, allowing request to continue"
+                );
+            } else {
+                #[cfg(feature = "analytics")]
+                {
+                    analytics = Some(MessageInfo {
+                        response_message: Some(
+                            "Client tenant id does not match request tenant id".into(),
+                        ),
+                        ..analytics.unwrap()
+                    });
+
+                    return Err((Error::MissmatchedTenantId, analytics));
+                }
+
+                return Err((Error::MissmatchedTenantId, None));
+            }
         }
 
-        #[cfg(not(feature = "analytics"))]
-        return Err((Error::MissmatchedTenantId, None));
+        #[cfg(not(feature = "multitenant"))]
+        {
+            #[cfg(feature = "analytics")]
+            {
+                analytics = Some(MessageInfo {
+                    response_message: Some(
+                        "Client tenant id does not match request tenant id".into(),
+                    ),
+                    ..analytics.unwrap()
+                });
 
-        #[cfg(feature = "analytics")]
-        return Err((Error::MissatchedTenantId, analytics));
+                return Err((Error::MissmatchedTenantId, analytics));
+            }
+
+            #[cfg(not(feature = "analytics"))]
+            return Err((Error::MissmatchedTenantId, None));
+        }
     }
 
     if let Ok(notification) = state
@@ -248,13 +285,12 @@ pub async fn handler_internal(
                 response_message: Some("Notification has already been received".into()),
                 ..analytics.unwrap()
             });
+
+            return Ok(((StatusCode::OK).into_response(), analytics));
         }
 
         #[cfg(not(feature = "analytics"))]
         return Ok(((StatusCode::OK).into_response(), None));
-
-        #[cfg(feature = "analytics")]
-        return Ok(((StatusCode::OK).into_response(), analytics));
     }
 
     let notification = state
@@ -289,13 +325,12 @@ pub async fn handler_internal(
                 response_message: Some("Notification has already been processed".into()),
                 ..analytics.unwrap()
             });
+
+            return Ok(((StatusCode::OK).into_response(), analytics));
         }
 
         #[cfg(not(feature = "analytics"))]
         return Ok(((StatusCode::OK).into_response(), None));
-
-        #[cfg(feature = "analytics")]
-        return Ok(((StatusCode::OK).into_response(), analytics));
     }
 
     let tenant = state
@@ -351,11 +386,9 @@ pub async fn handler_internal(
             response_message: Some("Delivered".into()),
             ..analytics.unwrap()
         });
+
+        return Ok(((StatusCode::ACCEPTED).into_response(), analytics));
     }
 
-    #[cfg(feature = "analytics")]
-    return Ok(((StatusCode::ACCEPTED).into_response(), analytics));
-
-    #[cfg(not(feature = "analytics"))]
     Ok(((StatusCode::ACCEPTED).into_response(), None))
 }

--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -205,6 +205,29 @@ pub async fn handler_internal(
         "fetched client to send notification"
     );
 
+    if tenant_id != client.tenant_id {
+        warn!(
+            %request_id,
+            %tenant_id,
+            client_id = %id,
+            "client tenant id does not match request tenant id"
+        );
+
+        #[cfg(feature = "analytics")]
+        {
+            analytics = Some(MessageInfo {
+                response_message: Some("Client tenant id does not match request tenant id".into()),
+                ..analytics.unwrap()
+            });
+        }
+
+        #[cfg(not(feature = "analytics"))]
+        return Err((Error::MissmatchedTenantId, None));
+
+        #[cfg(feature = "analytics")]
+        return Err((Error::MissatchedTenantId, analytics));
+    }
+
     if let Ok(notification) = state
         .notification_store
         .get_notification(&body.id, &tenant_id)

--- a/src/handlers/register_client.rs
+++ b/src/handlers/register_client.rs
@@ -90,6 +90,7 @@ pub async fn handler(
     state
         .client_store
         .create_client(&tenant_id, &client_id, Client {
+            tenant_id: tenant_id.clone(),
             push_type,
             token: body.token,
         })

--- a/src/stores/client.rs
+++ b/src/stores/client.rs
@@ -9,6 +9,7 @@ use {
 
 #[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
 pub struct Client {
+    pub tenant_id: String,
     pub push_type: ProviderKind,
     #[sqlx(rename = "device_token")]
     pub token: String,
@@ -49,7 +50,8 @@ impl ClientStore for sqlx::PgPool {
 
     async fn get_client(&self, tenant_id: &str, id: &str) -> stores::Result<Client> {
         let res = sqlx::query_as::<sqlx::postgres::Postgres, Client>(
-            "SELECT push_type, device_token FROM public.clients WHERE id = $1 and tenant_id = $2",
+            "SELECT tenant_id, push_type, device_token FROM public.clients WHERE id = $1 and \
+             tenant_id = $2",
         )
         .bind(id)
         .bind(tenant_id)


### PR DESCRIPTION
# Description

While debugging 5XX errors, I noticed there was a potential to send a notification to a client from another tenant. This shouldn't have been as issue as the `push_message` has signature validation and the relay behaviour should have been within specification. 

## How Has This Been Tested?
Builds locally

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update