### PR TITLE
feat: fcm verification

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@ let
 in
   with nixpkgs;
   stdenv.mkDerivation {
-    name = "music-reader-env";
+    name = "echo-server";
     buildInputs = [
       cargo
       rustc

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+let
+  nixpkgs = import <nixpkgs> {};
+in
+  with nixpkgs;
+  stdenv.mkDerivation {
+    name = "music-reader-env";
+    buildInputs = [
+      cargo
+      rustc
+      pkgconfig
+      openssl.dev
+      nix
+      protobuf
+    ];
+    OPENSSL_DEV=openssl.dev;
+  }

--- a/src/error.rs
+++ b/src/error.rs
@@ -162,6 +162,9 @@ pub enum Error {
 
     #[error("failed to load geoip database from s3")]
     GeoIpS3Failed,
+
+    #[error("invalid fcm api key")]
+    BadFcmApiKey,
 }
 
 impl IntoResponse for Error {
@@ -198,6 +201,18 @@ impl IntoResponse for Error {
                     message: e.to_string(),
                 }
             ], vec![]),
+            Error::BadFcmApiKey => crate::handlers::Response::new_failure(StatusCode::BAD_REQUEST, vec![
+                ResponseError {
+                    name: "bad_fcm_api_key".to_string(),
+                    message: "The provided API Key was not valid".to_string(),
+                }
+            ], vec![
+                ErrorField {
+                    field: "api_key".to_string(),
+                    description: "The provided API Key was not valid".to_string(),
+                    location: ErrorLocation::Body,
+                }
+            ]),
             Error::Database(e) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
                 ResponseError {
                     name: "sqlx".to_string(),

--- a/src/handlers/update_fcm.rs
+++ b/src/handlers/update_fcm.rs
@@ -56,8 +56,7 @@ pub async fn handler(
 
     // ---- checks
     let fcm_api_key = body.api_key.clone();
-    let mut test_message_builder =
-        fcm::MessageBuilder::new(&fcm_api_key, "wc-notification-test");
+    let mut test_message_builder = fcm::MessageBuilder::new(&fcm_api_key, "wc-notification-test");
     test_message_builder.dry_run(true);
     let test_message = test_message_builder.finalize();
     let test_notification = fcm::Client::new().send(test_message).await;

--- a/src/handlers/update_fcm.rs
+++ b/src/handlers/update_fcm.rs
@@ -55,13 +55,10 @@ pub async fn handler(
     }
 
     // ---- checks
-    let test_notification = fcm::Client::new()
-        .send(
-            fcm::MessageBuilder::new(&body.api_key.clone(), "wc-notification-test")
-                .dry_run(true)
-                .finalize(),
-        )
-        .await;
+    let test_message_builder =
+        fcm::MessageBuilder::new(&body.api_key.clone(), "wc-notification-test").dry_run(true);
+    let test_message = test_message_builder.finalize();
+    let test_notification = fcm::Client::new().send(test_message).await;
     match test_notification {
         Err(e) => match e {
             FcmError::Unauthorized => Err(BadFcmApiKey),

--- a/src/handlers/update_fcm.rs
+++ b/src/handlers/update_fcm.rs
@@ -56,8 +56,9 @@ pub async fn handler(
 
     // ---- checks
     let fcm_api_key = body.api_key.clone();
-    let test_message_builder =
-        fcm::MessageBuilder::new(&fcm_api_key, "wc-notification-test").dry_run(true);
+    let mut test_message_builder =
+        fcm::MessageBuilder::new(&fcm_api_key, "wc-notification-test");
+    test_message_builder.dry_run(true);
     let test_message = test_message_builder.finalize();
     let test_notification = fcm::Client::new().send(test_message).await;
     match test_notification {

--- a/src/handlers/update_fcm.rs
+++ b/src/handlers/update_fcm.rs
@@ -55,8 +55,9 @@ pub async fn handler(
     }
 
     // ---- checks
+    let fcm_api_key = body.api_key.clone();
     let test_message_builder =
-        fcm::MessageBuilder::new(&body.api_key.clone(), "wc-notification-test").dry_run(true);
+        fcm::MessageBuilder::new(&fcm_api_key, "wc-notification-test").dry_run(true);
     let test_message = test_message_builder.finalize();
     let test_notification = fcm::Client::new().send(test_message).await;
     match test_notification {

--- a/tests/functional/multitenant/fcm.rs
+++ b/tests/functional/multitenant/fcm.rs
@@ -1,0 +1,78 @@
+use {
+    crate::context::EchoServerContext,
+    echo_server::handlers::create_tenant::TenantRegisterBody,
+    random_string::generate,
+    test_context::test_context,
+};
+
+#[test_context(EchoServerContext)]
+#[tokio::test]
+async fn tenant_update_fcm(ctx: &mut EchoServerContext) {
+    let charset = "1234567890";
+    let random_tenant_id = generate(12, charset);
+    let payload = TenantRegisterBody {
+        id: random_tenant_id.clone(),
+    };
+
+    // Register tenant
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("http://{}/tenants", ctx.server.public_addr))
+        .json(&payload)
+        .send()
+        .await
+        .expect("Call failed");
+
+    // Send valid API Key
+    let api_key = env!("ECHO_TEST_FCM_KEY");
+    let form = reqwest::multipart::Form::new().text("api_key", api_key);
+
+    let response = client
+        .post(format!(
+            "http://{}/tenants/{}/fcm",
+            ctx.server.public_addr, &random_tenant_id
+        ))
+        .multipart(&form)
+        .send()
+        .await
+        .expect("Call failed");
+
+    assert!(
+        response.status().is_success(),
+        "Response was not successful"
+    );
+}
+
+#[test_context(EchoServerContext)]
+#[tokio::test]
+async fn tenant_update_fcm_bad(ctx: &mut EchoServerContext) {
+    let charset = "1234567890";
+    let random_tenant_id = generate(12, charset);
+    let payload = TenantRegisterBody {
+        id: random_tenant_id.clone(),
+    };
+
+    // Register tenant
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("http://{}/tenants", ctx.server.public_addr))
+        .json(&payload)
+        .send()
+        .await
+        .expect("Call failed");
+
+    // Send invalid API Key
+    let form = reqwest::multipart::Form::new().text("api_key", "invalid-key");
+
+    let response = client
+        .post(format!(
+            "http://{}/tenants/{}/fcm",
+            ctx.server.public_addr, &random_tenant_id
+        ))
+        .multipart(&form)
+        .send()
+        .await
+        .expect("Call failed");
+
+    assert!(!response.status().is_success(), "Response was successful");
+}

--- a/tests/functional/multitenant/mod.rs
+++ b/tests/functional/multitenant/mod.rs
@@ -1,6 +1,7 @@
 /// Tests against the handlers
 use {crate::context::EchoServerContext, test_context::test_context};
 
+mod fcm;
 mod tenancy;
 
 #[test_context(EchoServerContext)]


### PR DESCRIPTION
# Description
FCM API Keys are not validated to ensure they work with the FCM Api before the tenant is saved.

Resolves # (issue)

## How Has This Been Tested?
Adding interation tests to ensure it fails on invalid API Keys, and passes on valid ones. Requires valid FCM API Key in the env vars

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [x] Requires a e2e/integration test update