### PR TITLE
feat: handle invalid topic for token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,7 +1100,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "echo-server"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "a2",
  "async-recursion",

--- a/src/providers/apns.rs
+++ b/src/providers/apns.rs
@@ -103,6 +103,8 @@ impl PushProvider for ApnsProvider {
                     None => Err(Error::Apns(a2::Error::ResponseError(res))),
                     Some(response) => match response.reason {
                         ErrorReason::BadDeviceToken => Err(Error::BadDeviceToken),
+                        // Note: This will have the device deleted because the token was not for the configured topic
+                        ErrorReason::DeviceTokenNotForTopic => Err(Error::BadDeviceToken),
                         reason => Err(Error::ApnsResponse(reason)),
                     },
                 },

--- a/src/providers/apns.rs
+++ b/src/providers/apns.rs
@@ -103,7 +103,8 @@ impl PushProvider for ApnsProvider {
                     None => Err(Error::Apns(a2::Error::ResponseError(res))),
                     Some(response) => match response.reason {
                         ErrorReason::BadDeviceToken => Err(Error::BadDeviceToken),
-                        // Note: This will have the device deleted because the token was not for the configured topic
+                        // Note: This will have the device deleted because the token was not for the
+                        // configured topic
                         ErrorReason::DeviceTokenNotForTopic => Err(Error::BadDeviceToken),
                         reason => Err(Error::ApnsResponse(reason)),
                     },


### PR DESCRIPTION
# Description
Removes 5XX for invalid token with APNS, this could also be a tenant configuration issue however it is returned as a bad device issue due to the fact we can't check if the tenant has a wrongly configured topic on APNS

## How Has This Been Tested?
N/a, should notice 5XX dissapear after deploy

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update