### PR TITLE
chore: revert to info logs

### DIFF
--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -71,7 +71,7 @@ resource "aws_ecs_task_definition" "app_task_definition" {
       environment = [
         { name = "PORT", value = "8080" },
         { name = "PUBLIC_URL", value = "https://${var.fqdn}" },
-        { name = "LOG_LEVEL", value = "debug,echo-server=debug" },
+        { name = "LOG_LEVEL", value = "info,echo-server=info" },
         { name = "LOG_LEVEL_OTEL", value = "info,echo-server=trace" },
         { name = "DATABASE_URL", value = var.database_url },
         { name = "TENANT_DATABASE_URL", value = var.tenant_database_url },


### PR DESCRIPTION
# Description
Reverts back to `info` log level from `debug`

## How Has This Been Tested?
N/a, will just change log level fliters

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update