### PR TITLE
fix: remove use of PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,8 @@ jobs:
         with:
           body_path: GITHUB_CHANGELOG.md
           tag_name: ${{ steps.release.outputs.version }}
-          token: ${{ secrets.PAT }}
-          
+          # token: ${{ secrets.PAT }}
+
       - id: clean_version
         run: |
           version=$(echo "${{ steps.release.outputs.version }}" | sed 's/v//g')


### PR DESCRIPTION
# Description

Current PAT became invalid and is unnecessary because it defaults to github.token.

Resolves #189

## How Has This Been Tested?

Tested from experience

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update