### PR TITLE
fix: compilation errors with `functional_tests` flag

### DIFF
--- a/tests/functional/singletenant/push.rs
+++ b/tests/functional/singletenant/push.rs
@@ -59,7 +59,7 @@ async fn test_push(ctx: &mut EchoServerContext) {
     let topic = Uuid::new_v4().to_string();
     let blob = Uuid::new_v4().to_string();
     let push_message_payload = MessagePayload {
-        topic: Some(topic.into()),
+        topic: topic.into(),
         blob: blob.to_string(),
         flags: 0,
     };

--- a/tests/functional/stores/notification.rs
+++ b/tests/functional/stores/notification.rs
@@ -35,7 +35,7 @@ async fn notification_creation(ctx: &mut StoreContext) {
     let res = ctx
         .notifications
         .create_or_update_notification(&gen_id(), TENANT_ID, &client_id, &MessagePayload {
-            topic: None,
+            topic: String::new(),
             flags: 0,
             blob: "example-payload".to_string(),
         })


### PR DESCRIPTION
# Description

When the `--features functional_tests` flag is enabled there are few errors that break the building process:

```
error[E0308]: mismatched types
  --> tests/functional/singletenant/push.rs:62:16
   |
62 |         topic: Some(topic.into()),
   |                ^^^^^^^^^^^^^^^^^^ expected `String`, found `Option<_>`
   |
   = note: expected struct `std::string::String`
                found enum `Option<_>`

error[E0308]: mismatched types
  --> tests/functional/stores/notification.rs:38:20
   |
38 |             topic: None,
   |                    ^^^^ expected `String`, found `Option<_>`
   |
   = note: expected struct `std::string::String`
                found enum `Option<_>`
```

Seems that functional tests are out of sync with recent changes. To fix that I've changed fields to the expected types in the errors to make them in sync with the recent changes and make the functional tests compile.

Resolves #194 

## How Has This Been Tested?

It was tested by running `cargo test --features functional_tests`. 
The expected result is successful test building with the `functional_tests` enabled without errors.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update