### PR TITLE
fix: duplicated push tokens

### DIFF
--- a/src/stores/client.rs
+++ b/src/stores/client.rs
@@ -25,10 +25,18 @@ pub trait ClientStore {
 #[async_trait]
 impl ClientStore for sqlx::PgPool {
     async fn create_client(&self, tenant_id: &str, id: &str, client: Client) -> stores::Result<()> {
-        let mut query_builder = sqlx::QueryBuilder::new(
+        let mut transaction = self.begin().await?;
+
+        sqlx::query("DELETE FROM public.clients WHERE id = $1 OR device_token = $2")
+            .bind(id)
+            .bind(client.token.clone())
+            .execute(&mut transaction)
+            .await?;
+
+        let mut insert_query = sqlx::QueryBuilder::new(
             "INSERT INTO public.clients (id, tenant_id, push_type, device_token)",
         );
-        query_builder.push_values(
+        insert_query.push_values(
             vec![(id, tenant_id, client.push_type, client.token)],
             |mut b, client| {
                 b.push_bind(client.0)
@@ -37,13 +45,8 @@ impl ClientStore for sqlx::PgPool {
                     .push_bind(client.3);
             },
         );
-        query_builder.push(
-            " ON CONFLICT (id) DO UPDATE SET device_token = EXCLUDED.device_token, tenant_id = \
-             EXCLUDED.tenant_id, push_type = EXCLUDED.push_type",
-        );
-        let query = query_builder.build();
-
-        self.execute(query).await?;
+        insert_query.build().execute(&mut transaction).await?;
+        transaction.commit().await?;
 
         Ok(())
     }

--- a/tests/functional/stores/client.rs
+++ b/tests/functional/stores/client.rs
@@ -56,30 +56,77 @@ async fn client_creation_apns(ctx: &mut StoreContext) {
 
 #[test_context(StoreContext)]
 #[tokio::test]
-async fn client_upsert(ctx: &mut StoreContext) {
+async fn client_upsert_token(ctx: &mut StoreContext) {
     let id = gen_id();
 
-    let res = ctx
-        .clients
-        .create_client(TENANT_ID, &id, Client {
-            tenant_id: TENANT_ID.to_string(),
-            push_type: ProviderKind::Apns,
-            token: TOKEN.to_string(),
-        })
-        .await;
-
-    assert!(res.is_ok());
-
-    let upsert_res = ctx
-        .clients
+    // Initial Client creation
+    ctx.clients
         .create_client(TENANT_ID, &id, Client {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Fcm,
             token: TOKEN.to_string(),
         })
-        .await;
+        .await
+        .unwrap();
+    let insert_result = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
+    assert_eq!(insert_result.token, TOKEN);
 
-    assert!(upsert_res.is_ok());
+    // Updating token for the same id
+    let updated_token = gen_id();
+    ctx.clients
+        .create_client(TENANT_ID, &id, Client {
+            tenant_id: TENANT_ID.to_string(),
+            push_type: ProviderKind::Apns,
+            token: updated_token.clone(),
+        })
+        .await
+        .unwrap();
+    let updated_token_result = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
+    assert_eq!(updated_token_result.token, updated_token);
+
+    // Cleaning up records
+    ctx.clients.delete_client(TENANT_ID, &id).await.unwrap();
+}
+
+#[test_context(StoreContext)]
+#[tokio::test]
+async fn client_upsert_id(ctx: &mut StoreContext) {
+    let id = gen_id();
+
+    // Initial Client creation
+    ctx.clients
+        .create_client(TENANT_ID, &id, Client {
+            tenant_id: TENANT_ID.to_string(),
+            push_type: ProviderKind::Fcm,
+            token: TOKEN.to_string(),
+        })
+        .await
+        .unwrap();
+    let insert_result = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
+    assert_eq!(insert_result.token, TOKEN);
+
+    // Updating id for the same token
+    let updated_id = gen_id();
+    ctx.clients
+        .create_client(TENANT_ID, &updated_id, Client {
+            tenant_id: TENANT_ID.to_string(),
+            push_type: ProviderKind::Fcm,
+            token: TOKEN.to_string(),
+        })
+        .await
+        .unwrap();
+    let updated_id_result = ctx
+        .clients
+        .get_client(TENANT_ID, &updated_id)
+        .await
+        .unwrap();
+    assert_eq!(updated_id_result.token, TOKEN);
+
+    // Cleaning up records
+    ctx.clients
+        .delete_client(TENANT_ID, &updated_id)
+        .await
+        .unwrap();
 }
 
 #[test_context(StoreContext)]


### PR DESCRIPTION
# Description

When an app is reinstalled, the device ID (table clients -> column id) is changed, but the token remains the same causing the same token to be inserted for a second device ID as clients -> device_token. 

To make upset for both `id` and `device_token` following changes are made:
- The upset query for the client creation was changed from using `ON CONFLICT` to `DELETE`  and `INSERT` wrapped into a transaction because unfortunately, we can't use `ON CONFLICT` with the exclusion conditions.
- The `client_upsert` functional test was changed to test the new behavior in `create_client` in the following way:
  1. Insert a new client `id` and `device_token` where neither exists, expecting a new row to be added.
  2. Insert a new token with the existing client `id`, expecting `device_token` to be replaced.
  3. Insert new client `id` with same `device_token`, expecting client `id` to be replaced.

Resolves #193

The following migration changes were extracted from this issue into #201 :
> - To change the current behavior to upset for both `id` and `device_token` the second `UNIQUE` constraint for `device_token` is added to the SQL migrations.
> - Removing all duplicating `device_token` records and leaving the one recent is implemented as a SQL script in migrations before the `UNIQUE` constraint for `device_token` is added.

## How Has This Been Tested?

**To fix the building errors for the `--features functional_tests` flag please apply or cherry-pick the #195 first.**

Changes are covered by the `client_upsert_id` and `client_upsert_token` functional tests included in this PR.

To test it locally start the PostgreSQL local instances:
```
docker run \
  -p 5432:5432 \
  -e POSTGRES_HOST_AUTH_METHOD=trust \
  --name echo-server-pg \
  -d postgres

docker run \
  -p 5433:5432 \
  -e POSTGRES_HOST_AUTH_METHOD=trust \
  --name echo-server-tenant-pg \
  -d postgres
```

Build and run the `client_upsert_id` and `client_upsert_token` tests:

```
cargo t --features functional_tests functional::stores::client::client_upsert_id  -- --exact
cargo t --features functional_tests functional::stores::client::client_upsert_token  -- --exact
```

The expected result is tests should pass.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update