### PR TITLE
chore: fix byzantine failures on functional tests

### DIFF
--- a/tests/functional/multitenant/apns.rs
+++ b/tests/functional/multitenant/apns.rs
@@ -1,8 +1,6 @@
 use {
-    crate::context::EchoServerContext,
-    echo_server::handlers::create_tenant::TenantRegisterBody,
-    random_string::generate,
-    test_context::test_context,
+    crate::context::EchoServerContext, echo_server::handlers::create_tenant::TenantRegisterBody,
+    random_string::generate, test_context::test_context,
 };
 
 // #[test_context(EchoServerContext)]
@@ -55,7 +53,7 @@ async fn tenant_update_apns_bad_token(ctx: &mut EchoServerContext) {
 
     // Register tenant
     let client = reqwest::Client::new();
-    let response = client
+    client
         .post(format!("http://{}/tenants", ctx.server.public_addr))
         .json(&payload)
         .send()
@@ -92,7 +90,7 @@ async fn tenant_update_apns_bad_certificate(ctx: &mut EchoServerContext) {
 
     // Register tenant
     let client = reqwest::Client::new();
-    let response = client
+    client
         .post(format!("http://{}/tenants", ctx.server.public_addr))
         .json(&payload)
         .send()

--- a/tests/functional/multitenant/apns.rs
+++ b/tests/functional/multitenant/apns.rs
@@ -1,6 +1,8 @@
 use {
-    crate::context::EchoServerContext, echo_server::handlers::create_tenant::TenantRegisterBody,
-    random_string::generate, test_context::test_context,
+    crate::context::EchoServerContext,
+    echo_server::handlers::create_tenant::TenantRegisterBody,
+    random_string::generate,
+    test_context::test_context,
 };
 
 // #[test_context(EchoServerContext)]

--- a/tests/functional/multitenant/fcm.rs
+++ b/tests/functional/multitenant/fcm.rs
@@ -1,6 +1,8 @@
 use {
-    crate::context::EchoServerContext, echo_server::handlers::create_tenant::TenantRegisterBody,
-    random_string::generate, test_context::test_context,
+    crate::context::EchoServerContext,
+    echo_server::handlers::create_tenant::TenantRegisterBody,
+    random_string::generate,
+    test_context::test_context,
 };
 
 #[test_context(EchoServerContext)]

--- a/tests/functional/multitenant/fcm.rs
+++ b/tests/functional/multitenant/fcm.rs
@@ -1,8 +1,6 @@
 use {
-    crate::context::EchoServerContext,
-    echo_server::handlers::create_tenant::TenantRegisterBody,
-    random_string::generate,
-    test_context::test_context,
+    crate::context::EchoServerContext, echo_server::handlers::create_tenant::TenantRegisterBody,
+    random_string::generate, test_context::test_context,
 };
 
 #[test_context(EchoServerContext)]
@@ -18,7 +16,7 @@ async fn tenant_update_fcm(ctx: &mut EchoServerContext) {
 
     // Register tenant
     let client = reqwest::Client::new();
-    let response = client
+    client
         .post(format!("http://{}/tenants", ctx.server.public_addr))
         .json(&payload)
         .send()
@@ -56,7 +54,7 @@ async fn tenant_update_fcm_bad(ctx: &mut EchoServerContext) {
 
     // Register tenant
     let client = reqwest::Client::new();
-    let response = client
+    client
         .post(format!("http://{}/tenants", ctx.server.public_addr))
         .json(&payload)
         .send()

--- a/tests/functional/stores/client.rs
+++ b/tests/functional/stores/client.rs
@@ -7,78 +7,103 @@ use {
     test_context::test_context,
 };
 
-pub const TOKEN: &str = "noop-111-222-333";
-
 #[test_context(StoreContext)]
 #[tokio::test]
 async fn client_creation(ctx: &mut StoreContext) {
-    let res = ctx
-        .clients
-        .create_client(TENANT_ID, &gen_id(), Client {
-            tenant_id: TENANT_ID.to_string(),
-            push_type: ProviderKind::Noop,
-            token: TOKEN.to_string(),
-        })
-        .await;
-
-    assert!(res.is_ok())
+    let id = format!("id-{}", gen_id());
+    let token = format!("token-{}", gen_id());
+    ctx.clients
+        .create_client(
+            TENANT_ID,
+            &id,
+            Client {
+                tenant_id: TENANT_ID.to_string(),
+                push_type: ProviderKind::Noop,
+                token,
+            },
+        )
+        .await
+        .unwrap();
+    // Cleaning up records
+    ctx.clients.delete_client(TENANT_ID, &id).await.unwrap();
 }
 
 #[test_context(StoreContext)]
 #[tokio::test]
 async fn client_creation_fcm(ctx: &mut StoreContext) {
-    let res = ctx
-        .clients
-        .create_client(TENANT_ID, &gen_id(), Client {
-            tenant_id: TENANT_ID.to_string(),
-            push_type: ProviderKind::Fcm,
-            token: TOKEN.to_string(),
-        })
-        .await;
-
-    assert!(res.is_ok())
+    let id = format!("id-{}", gen_id());
+    let token = format!("token-{}", gen_id());
+    ctx.clients
+        .create_client(
+            TENANT_ID,
+            &id,
+            Client {
+                tenant_id: TENANT_ID.to_string(),
+                push_type: ProviderKind::Fcm,
+                token,
+            },
+        )
+        .await
+        .unwrap();
+    // Cleaning up records
+    ctx.clients.delete_client(TENANT_ID, &id).await.unwrap();
 }
 
 #[test_context(StoreContext)]
 #[tokio::test]
 async fn client_creation_apns(ctx: &mut StoreContext) {
-    let res = ctx
-        .clients
-        .create_client(TENANT_ID, &gen_id(), Client {
-            tenant_id: TENANT_ID.to_string(),
-            push_type: ProviderKind::Apns,
-            token: TOKEN.to_string(),
-        })
-        .await;
-
-    assert!(res.is_ok())
+    let id = format!("id-{}", gen_id());
+    let token = format!("token-{}", gen_id());
+    ctx.clients
+        .create_client(
+            TENANT_ID,
+            &id,
+            Client {
+                tenant_id: TENANT_ID.to_string(),
+                push_type: ProviderKind::Apns,
+                token,
+            },
+        )
+        .await
+        .unwrap();
+    // Cleaning up records
+    ctx.clients.delete_client(TENANT_ID, &id).await.unwrap();
 }
 
 #[test_context(StoreContext)]
 #[tokio::test]
 async fn client_upsert_token(ctx: &mut StoreContext) {
-    let id = gen_id();
+    let id = format!("id-{}", gen_id());
+    let token = format!("token-{}", gen_id());
 
     // Initial Client creation
     ctx.clients
-        .create_client(TENANT_ID, &id, Client {
-            tenant_id: TENANT_ID.to_string(),
-            push_type: ProviderKind::Fcm,
-            token: TOKEN.to_string(),
-        })
+        .create_client(
+            TENANT_ID,
+            &id,
+            Client {
+                tenant_id: TENANT_ID.to_string(),
+                push_type: ProviderKind::Fcm,
+                token: token.clone(),
+            },
+        )
         .await
         .unwrap();
     let insert_result = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
-    assert_eq!(insert_result.token, TOKEN);
+    assert_eq!(insert_result.token, token);
 
     // Updating token for the same id
-    let updated_token = gen_id();
+    let updated_token = format!("token-{}", gen_id());
     ctx.clients
-        .create_client(TENANT_ID, &id, Client {
-            tenant_id: TENANT_ID.to_string(),
-            push_type: ProviderKind::Apns,
-            token: updated_token.clone(),
-        })
+        .create_client(
+            TENANT_ID,
+            &id,
+            Client {
+                tenant_id: TENANT_ID.to_string(),
+                push_type: ProviderKind::Apns,
+                token: updated_token.clone(),
+            },
+        )
         .await
         .unwrap();
     let updated_token_result = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
@@ -91,28 +116,37 @@ async fn client_upsert_token(ctx: &mut StoreContext) {
 #[test_context(StoreContext)]
 #[tokio::test]
 async fn client_upsert_id(ctx: &mut StoreContext) {
-    let id = gen_id();
+    let id = format!("id-{}", gen_id());
+    let token = format!("token-{}", gen_id());
 
     // Initial Client creation
     ctx.clients
-        .create_client(TENANT_ID, &id, Client {
-            tenant_id: TENANT_ID.to_string(),
-            push_type: ProviderKind::Fcm,
-            token: TOKEN.to_string(),
-        })
+        .create_client(
+            TENANT_ID,
+            &id,
+            Client {
+                tenant_id: TENANT_ID.to_string(),
+                push_type: ProviderKind::Fcm,
+                token: token.clone(),
+            },
+        )
         .await
         .unwrap();
     let insert_result = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
-    assert_eq!(insert_result.token, TOKEN);
+    assert_eq!(insert_result.token, token.clone());
 
     // Updating id for the same token
     let updated_id = gen_id();
     ctx.clients
-        .create_client(TENANT_ID, &updated_id, Client {
-            tenant_id: TENANT_ID.to_string(),
-            push_type: ProviderKind::Fcm,
-            token: TOKEN.to_string(),
-        })
+        .create_client(
+            TENANT_ID,
+            &updated_id,
+            Client {
+                tenant_id: TENANT_ID.to_string(),
+                push_type: ProviderKind::Fcm,
+                token: token.clone(),
+            },
+        )
         .await
         .unwrap();
     let updated_id_result = ctx
@@ -120,7 +154,7 @@ async fn client_upsert_id(ctx: &mut StoreContext) {
         .get_client(TENANT_ID, &updated_id)
         .await
         .unwrap();
-    assert_eq!(updated_id_result.token, TOKEN);
+    assert_eq!(updated_id_result.token, token);
 
     // Cleaning up records
     ctx.clients
@@ -132,46 +166,48 @@ async fn client_upsert_id(ctx: &mut StoreContext) {
 #[test_context(StoreContext)]
 #[tokio::test]
 async fn client_deletion(ctx: &mut StoreContext) {
-    let id = gen_id();
+    let id = format!("id-{}", gen_id());
+    let token = format!("token-{}", gen_id());
 
-    let res = ctx
-        .clients
-        .create_client(TENANT_ID, &id, Client {
-            tenant_id: TENANT_ID.to_string(),
-            push_type: ProviderKind::Noop,
-            token: TOKEN.to_string(),
-        })
-        .await;
-
-    assert!(res.is_ok());
-
-    let delete_res = ctx.clients.delete_client(TENANT_ID, &id).await;
-
-    assert!(delete_res.is_ok());
+    ctx.clients
+        .create_client(
+            TENANT_ID,
+            &id,
+            Client {
+                tenant_id: TENANT_ID.to_string(),
+                push_type: ProviderKind::Noop,
+                token,
+            },
+        )
+        .await
+        .unwrap();
+    ctx.clients.delete_client(TENANT_ID, &id).await.unwrap();
 }
 
 #[test_context(StoreContext)]
 #[tokio::test]
 async fn client_fetch(ctx: &mut StoreContext) {
-    let id = gen_id();
+    let id = format!("id-{}", gen_id());
+    let token = format!("token-{}", gen_id());
 
-    let res = ctx
-        .clients
-        .create_client(TENANT_ID, &id, Client {
-            tenant_id: TENANT_ID.to_string(),
-            push_type: ProviderKind::Noop,
-            token: TOKEN.to_string(),
-        })
-        .await;
+    ctx.clients
+        .create_client(
+            TENANT_ID,
+            &id,
+            Client {
+                tenant_id: TENANT_ID.to_string(),
+                push_type: ProviderKind::Noop,
+                token: token.clone(),
+            },
+        )
+        .await
+        .unwrap();
 
-    assert!(res.is_ok());
+    let client = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
 
-    let client_res = ctx.clients.get_client(TENANT_ID, &id).await;
-
-    assert!(client_res.is_ok());
-
-    let client = client_res.expect("failed to unwrap client");
-
-    assert_eq!(client.token, TOKEN.to_string());
+    assert_eq!(client.token, token);
     assert_eq!(client.push_type, ProviderKind::Noop);
+
+    // Cleaning up records
+    ctx.clients.delete_client(TENANT_ID, &id).await.unwrap();
 }

--- a/tests/functional/stores/client.rs
+++ b/tests/functional/stores/client.rs
@@ -13,15 +13,11 @@ async fn client_creation(ctx: &mut StoreContext) {
     let id = format!("id-{}", gen_id());
     let token = format!("token-{}", gen_id());
     ctx.clients
-        .create_client(
-            TENANT_ID,
-            &id,
-            Client {
-                tenant_id: TENANT_ID.to_string(),
-                push_type: ProviderKind::Noop,
-                token,
-            },
-        )
+        .create_client(TENANT_ID, &id, Client {
+            tenant_id: TENANT_ID.to_string(),
+            push_type: ProviderKind::Noop,
+            token,
+        })
         .await
         .unwrap();
     // Cleaning up records
@@ -34,15 +30,11 @@ async fn client_creation_fcm(ctx: &mut StoreContext) {
     let id = format!("id-{}", gen_id());
     let token = format!("token-{}", gen_id());
     ctx.clients
-        .create_client(
-            TENANT_ID,
-            &id,
-            Client {
-                tenant_id: TENANT_ID.to_string(),
-                push_type: ProviderKind::Fcm,
-                token,
-            },
-        )
+        .create_client(TENANT_ID, &id, Client {
+            tenant_id: TENANT_ID.to_string(),
+            push_type: ProviderKind::Fcm,
+            token,
+        })
         .await
         .unwrap();
     // Cleaning up records
@@ -55,15 +47,11 @@ async fn client_creation_apns(ctx: &mut StoreContext) {
     let id = format!("id-{}", gen_id());
     let token = format!("token-{}", gen_id());
     ctx.clients
-        .create_client(
-            TENANT_ID,
-            &id,
-            Client {
-                tenant_id: TENANT_ID.to_string(),
-                push_type: ProviderKind::Apns,
-                token,
-            },
-        )
+        .create_client(TENANT_ID, &id, Client {
+            tenant_id: TENANT_ID.to_string(),
+            push_type: ProviderKind::Apns,
+            token,
+        })
         .await
         .unwrap();
     // Cleaning up records
@@ -78,15 +66,11 @@ async fn client_upsert_token(ctx: &mut StoreContext) {
 
     // Initial Client creation
     ctx.clients
-        .create_client(
-            TENANT_ID,
-            &id,
-            Client {
-                tenant_id: TENANT_ID.to_string(),
-                push_type: ProviderKind::Fcm,
-                token: token.clone(),
-            },
-        )
+        .create_client(TENANT_ID, &id, Client {
+            tenant_id: TENANT_ID.to_string(),
+            push_type: ProviderKind::Fcm,
+            token: token.clone(),
+        })
         .await
         .unwrap();
     let insert_result = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
@@ -95,15 +79,11 @@ async fn client_upsert_token(ctx: &mut StoreContext) {
     // Updating token for the same id
     let updated_token = format!("token-{}", gen_id());
     ctx.clients
-        .create_client(
-            TENANT_ID,
-            &id,
-            Client {
-                tenant_id: TENANT_ID.to_string(),
-                push_type: ProviderKind::Apns,
-                token: updated_token.clone(),
-            },
-        )
+        .create_client(TENANT_ID, &id, Client {
+            tenant_id: TENANT_ID.to_string(),
+            push_type: ProviderKind::Apns,
+            token: updated_token.clone(),
+        })
         .await
         .unwrap();
     let updated_token_result = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
@@ -121,15 +101,11 @@ async fn client_upsert_id(ctx: &mut StoreContext) {
 
     // Initial Client creation
     ctx.clients
-        .create_client(
-            TENANT_ID,
-            &id,
-            Client {
-                tenant_id: TENANT_ID.to_string(),
-                push_type: ProviderKind::Fcm,
-                token: token.clone(),
-            },
-        )
+        .create_client(TENANT_ID, &id, Client {
+            tenant_id: TENANT_ID.to_string(),
+            push_type: ProviderKind::Fcm,
+            token: token.clone(),
+        })
         .await
         .unwrap();
     let insert_result = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
@@ -138,15 +114,11 @@ async fn client_upsert_id(ctx: &mut StoreContext) {
     // Updating id for the same token
     let updated_id = gen_id();
     ctx.clients
-        .create_client(
-            TENANT_ID,
-            &updated_id,
-            Client {
-                tenant_id: TENANT_ID.to_string(),
-                push_type: ProviderKind::Fcm,
-                token: token.clone(),
-            },
-        )
+        .create_client(TENANT_ID, &updated_id, Client {
+            tenant_id: TENANT_ID.to_string(),
+            push_type: ProviderKind::Fcm,
+            token: token.clone(),
+        })
         .await
         .unwrap();
     let updated_id_result = ctx
@@ -170,15 +142,11 @@ async fn client_deletion(ctx: &mut StoreContext) {
     let token = format!("token-{}", gen_id());
 
     ctx.clients
-        .create_client(
-            TENANT_ID,
-            &id,
-            Client {
-                tenant_id: TENANT_ID.to_string(),
-                push_type: ProviderKind::Noop,
-                token,
-            },
-        )
+        .create_client(TENANT_ID, &id, Client {
+            tenant_id: TENANT_ID.to_string(),
+            push_type: ProviderKind::Noop,
+            token,
+        })
         .await
         .unwrap();
     ctx.clients.delete_client(TENANT_ID, &id).await.unwrap();
@@ -191,15 +159,11 @@ async fn client_fetch(ctx: &mut StoreContext) {
     let token = format!("token-{}", gen_id());
 
     ctx.clients
-        .create_client(
-            TENANT_ID,
-            &id,
-            Client {
-                tenant_id: TENANT_ID.to_string(),
-                push_type: ProviderKind::Noop,
-                token: token.clone(),
-            },
-        )
+        .create_client(TENANT_ID, &id, Client {
+            tenant_id: TENANT_ID.to_string(),
+            push_type: ProviderKind::Noop,
+            token: token.clone(),
+        })
         .await
         .unwrap();
 

--- a/tests/functional/stores/notification.rs
+++ b/tests/functional/stores/notification.rs
@@ -1,26 +1,29 @@
 use {
     crate::{
         context::StoreContext,
-        functional::stores::{client::TOKEN, gen_id, TENANT_ID},
+        functional::stores::{gen_id, TENANT_ID},
     },
     echo_server::{
-        handlers::push_message::MessagePayload,
-        providers::ProviderKind,
-        state::ClientStoreArc,
+        handlers::push_message::MessagePayload, providers::ProviderKind, state::ClientStoreArc,
         stores::client::Client,
     },
     test_context::test_context,
 };
 
 pub async fn get_client(client_store: &ClientStoreArc) -> String {
-    let id = gen_id();
+    let id = format!("id-{}", gen_id());
+    let token = format!("token-{}", gen_id());
 
     client_store
-        .create_client(TENANT_ID, &id, Client {
-            tenant_id: TENANT_ID.to_string(),
-            push_type: ProviderKind::Noop,
-            token: TOKEN.to_string(),
-        })
+        .create_client(
+            TENANT_ID,
+            &id,
+            Client {
+                tenant_id: TENANT_ID.to_string(),
+                push_type: ProviderKind::Noop,
+                token,
+            },
+        )
         .await
         .expect("failed to create client for notification test");
 
@@ -34,11 +37,16 @@ async fn notification_creation(ctx: &mut StoreContext) {
 
     let res = ctx
         .notifications
-        .create_or_update_notification(&gen_id(), TENANT_ID, &client_id, &MessagePayload {
-            topic: String::new(),
-            flags: 0,
-            blob: "example-payload".to_string(),
-        })
+        .create_or_update_notification(
+            &gen_id(),
+            TENANT_ID,
+            &client_id,
+            &MessagePayload {
+                topic: String::new(),
+                flags: 0,
+                blob: "example-payload".to_string(),
+            },
+        )
         .await;
 
     assert!(res.is_ok())

--- a/tests/functional/stores/notification.rs
+++ b/tests/functional/stores/notification.rs
@@ -4,7 +4,9 @@ use {
         functional::stores::{gen_id, TENANT_ID},
     },
     echo_server::{
-        handlers::push_message::MessagePayload, providers::ProviderKind, state::ClientStoreArc,
+        handlers::push_message::MessagePayload,
+        providers::ProviderKind,
+        state::ClientStoreArc,
         stores::client::Client,
     },
     test_context::test_context,
@@ -15,15 +17,11 @@ pub async fn get_client(client_store: &ClientStoreArc) -> String {
     let token = format!("token-{}", gen_id());
 
     client_store
-        .create_client(
-            TENANT_ID,
-            &id,
-            Client {
-                tenant_id: TENANT_ID.to_string(),
-                push_type: ProviderKind::Noop,
-                token,
-            },
-        )
+        .create_client(TENANT_ID, &id, Client {
+            tenant_id: TENANT_ID.to_string(),
+            push_type: ProviderKind::Noop,
+            token,
+        })
         .await
         .expect("failed to create client for notification test");
 
@@ -37,16 +35,11 @@ async fn notification_creation(ctx: &mut StoreContext) {
 
     let res = ctx
         .notifications
-        .create_or_update_notification(
-            &gen_id(),
-            TENANT_ID,
-            &client_id,
-            &MessagePayload {
-                topic: String::new(),
-                flags: 0,
-                blob: "example-payload".to_string(),
-            },
-        )
+        .create_or_update_notification(&gen_id(), TENANT_ID, &client_id, &MessagePayload {
+            topic: String::new(),
+            flags: 0,
+            blob: "example-payload".to_string(),
+        })
         .await;
 
     assert!(res.is_ok())


### PR DESCRIPTION
# Description

To fix byzantine failures on functional tests following changes are made:
- Make `TOKEN` [unique for each test](https://github.com/WalletConnect/echo-server/pull/206/commits/7a8fc2c50084803ee3e485dc127457377b98188a) for running tests in parallel and prevent data race conditions in the test PG database,
- Fixing warnings in functional unit tests [about unused variables](https://github.com/WalletConnect/echo-server/pull/206/commits/047facd9091faf4a8e75d4537c32da8d06d473c1).

Resolves #205

## How Has This Been Tested?

Automatically tests by the CI unit test workflow by iterating it 3-5 times.
The expected result is passing the CI unit tests all of the time.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update