### PR TITLE
bug: revert back token dedup

### DIFF
--- a/tests/functional/stores/client.rs
+++ b/tests/functional/stores/client.rs
@@ -56,77 +56,30 @@ async fn client_creation_apns(ctx: &mut StoreContext) {
 
 #[test_context(StoreContext)]
 #[tokio::test]
-async fn client_upsert_token(ctx: &mut StoreContext) {
+async fn client_upsert(ctx: &mut StoreContext) {
     let id = gen_id();
 
-    // Initial Client creation
-    ctx.clients
-        .create_client(TENANT_ID, &id, Client {
-            tenant_id: TENANT_ID.to_string(),
-            push_type: ProviderKind::Fcm,
-            token: TOKEN.to_string(),
-        })
-        .await
-        .unwrap();
-    let insert_result = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
-    assert_eq!(insert_result.token, TOKEN);
-
-    // Updating token for the same id
-    let updated_token = gen_id();
-    ctx.clients
+    let res = ctx
+        .clients
         .create_client(TENANT_ID, &id, Client {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Apns,
-            token: updated_token.clone(),
+            token: TOKEN.to_string(),
         })
-        .await
-        .unwrap();
-    let updated_token_result = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
-    assert_eq!(updated_token_result.token, updated_token);
+        .await;
 
-    // Cleaning up records
-    ctx.clients.delete_client(TENANT_ID, &id).await.unwrap();
-}
+    assert!(res.is_ok());
 
-#[test_context(StoreContext)]
-#[tokio::test]
-async fn client_upsert_id(ctx: &mut StoreContext) {
-    let id = gen_id();
-
-    // Initial Client creation
-    ctx.clients
+    let upsert_res = ctx
+        .clients
         .create_client(TENANT_ID, &id, Client {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Fcm,
             token: TOKEN.to_string(),
         })
-        .await
-        .unwrap();
-    let insert_result = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
-    assert_eq!(insert_result.token, TOKEN);
+        .await;
 
-    // Updating id for the same token
-    let updated_id = gen_id();
-    ctx.clients
-        .create_client(TENANT_ID, &updated_id, Client {
-            tenant_id: TENANT_ID.to_string(),
-            push_type: ProviderKind::Fcm,
-            token: TOKEN.to_string(),
-        })
-        .await
-        .unwrap();
-    let updated_id_result = ctx
-        .clients
-        .get_client(TENANT_ID, &updated_id)
-        .await
-        .unwrap();
-    assert_eq!(updated_id_result.token, TOKEN);
-
-    // Cleaning up records
-    ctx.clients
-        .delete_client(TENANT_ID, &updated_id)
-        .await
-        .unwrap();
+    assert!(upsert_res.is_ok());
 }
 
 #[test_context(StoreContext)]


### PR DESCRIPTION
# Description

Reverting the token deduplication #196 because of the following errors occurred:
```
2023-09-21T16:19:44.393587Z  WARN error occurred while testing the connection on-release: error returned from database: update or delete on table "clients" violates foreign key constraint "fk_notifications_client_id" on table "notifications"
```

Resolves # (issue)

## How Has This Been Tested?

Shoud be covered by CI

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update