### PR TITLE
chore: revert 196

### DIFF
--- a/src/stores/client.rs
+++ b/src/stores/client.rs
@@ -31,18 +31,10 @@ impl ClientStore for sqlx::PgPool {
             client.token
         );
 
-        let mut transaction = self.begin().await?;
-
-        sqlx::query("DELETE FROM public.clients WHERE id = $1 OR device_token = $2")
-            .bind(id)
-            .bind(client.token.clone())
-            .execute(&mut transaction)
-            .await?;
-
-        let mut insert_query = sqlx::QueryBuilder::new(
+        let mut query_builder = sqlx::QueryBuilder::new(
             "INSERT INTO public.clients (id, tenant_id, push_type, device_token)",
         );
-        insert_query.push_values(
+        query_builder.push_values(
             vec![(id, tenant_id, client.push_type, client.token)],
             |mut b, client| {
                 b.push_bind(client.0)
@@ -51,8 +43,13 @@ impl ClientStore for sqlx::PgPool {
                     .push_bind(client.3);
             },
         );
-        insert_query.build().execute(&mut transaction).await?;
-        transaction.commit().await?;
+        query_builder.push(
+            " ON CONFLICT (id) DO UPDATE SET device_token = EXCLUDED.device_token, tenant_id = \
+             EXCLUDED.tenant_id, push_type = EXCLUDED.push_type",
+        );
+        let query = query_builder.build();
+
+        self.execute(query).await?;
 
         Ok(())
     }

--- a/src/stores/notification.rs
+++ b/src/stores/notification.rs
@@ -29,8 +29,8 @@ pub trait NotificationStore {
         client_id: &str,
         payload: &MessagePayload,
     ) -> stores::Result<Notification>;
-    async fn get_notification(&self, tenant_id: &str, id: &str) -> stores::Result<Notification>;
-    async fn delete_notification(&self, tenant_id: &str, id: &str) -> stores::Result<()>;
+    async fn get_notification(&self, id: &str, tenant_id: &str) -> stores::Result<Notification>;
+    async fn delete_notification(&self, id: &str, tenant_id: &str) -> stores::Result<()>;
 }
 
 #[async_trait]


### PR DESCRIPTION
# Description

#196 overlooked foreign key constraint requiring messages to be deleted before client can be deleted. Reverting for now.

```
2023-09-21T16:19:44.393587Z  WARN error occurred while testing the connection on-release: error returned from database: update or delete on table "clients" violates foreign key constraint "fk_notifications_client_id" on table "notifications"
```

Resolves # (issue)

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update