### PR TITLE
fix: alter notifications constraint with `ON DELETE CASCADE`

### DIFF
--- a/migrations/1695381202_alter_notifications_constraint.sql
+++ b/migrations/1695381202_alter_notifications_constraint.sql
@@ -1,0 +1,6 @@
+ALTER TABLE public.notifications
+DROP CONSTRAINT fk_notifications_client_id,
+ADD CONSTRAINT fk_notifications_client_id 
+    FOREIGN KEY (client_id)
+    REFERENCES public.clients (id)
+    ON DELETE CASCADE;


### PR DESCRIPTION
# Description

This PR adds SQL migration file with changing the `fk_notifications_client_id` constraint to include `ON DELETE CASCADE` to fix the `delete on table "clients" violates foreign key constraint "fk_notifications_client_id"` error.

With this change removing records from the `clients` table will automatically remove related to the `clients.id` records in the `notifications` table.

Resolves #212 

## Test plan

**Pre-requirements:**

To test the sqlx migrations we should use the [sqlx-cli](https://crates.io/crates/sqlx-cli) tool:

```
cargo install sqlx-cli
```

**Step 1:**
To test the migration properly we should populate the table with different records including duplicated `device_token` records in the `clients` and `notifications` tables. 
To mimic the real database behavior we will use the [test migration SQL script with the data](https://gist.github.com/geekbrother/72edfa9176263287c2e1626ae36df652) to be inserted into the database BEFORE the new migration SQL script.

Please download the script to the `/migrations` folder:

```
curl -o migrations/1690000000_TEST_populate_with_duplicates.sql https://gist.githubusercontent.com/geekbrother/72edfa9176263287c2e1626ae36df652/raw/e842759dc92bf362e0c52aca1d3590612408a192/populate_clients_with_duplicates.sql
```

**Step 2:**

Also, we should download the [migration SQL script from](https://gist.github.com/geekbrother/89166e4221199058a7a55f1a7000a03a) #202 with removing duplicates and adding the unique constraint to the `device_token` to mimic removing records from the `clients` table and test the follow-up migration as well AFTER this PR migration script.

```
curl -o migrations/9000000000_TEST_delete_duplicates_add_constraint.sql https://gist.githubusercontent.com/geekbrother/89166e4221199058a7a55f1a7000a03a/raw/a48ba4b577078269a83f8cd3cc464a50b6be51d5/delete_duplicates.sql
```

After that, we should have the following migrations scripts in our `/migrations` folder:

```
1664117744_init.sql
1664117746_create-clients.sql
1664117751_create-notifications.sql
1667510128_add-tenant-id.sql
1675269994_add-sandbox-to-enum.sql
1690000000_TEST_populate_with_duplicates.sql   <--- Populating the database with the data BEFORE
1695381202_alter_notifications_constraint.sql   <--- Migration from this PR for altering the constraint
9000000000_TEST_delete_duplicates_add_constraint.sql  <--- Deleting duplicated records and test `ON DELETE CASCADE` AFTER
```

**Step 3:**

Start the Postgres docker container:

```
docker run \
  -p 5432:5432 \
  -e POSTGRES_HOST_AUTH_METHOD=trust \
  --name echo-server-pg \
  -d postgres
```

**Step 4:**

Now we can start the sqlx migration to test its correctness and results using the sqlx-cli:

```
sqlx migrate run --database-url postgres://postgres@localhost/postgres
```

The expected result is that all migration steps should be passed successfully:

```
➜  echo-server git:(fix/alter_notifications_client_id_constraint) ✗ sqlx migrate run --database-url postgres://postgres@localhost/postgres
Applied 1664117744/migrate init (1.861333ms)
Applied 1664117746/migrate create-clients (6.762958ms)
Applied 1664117751/migrate create-notifications (5.017792ms)
Applied 1667510128/migrate add-tenant-id (1.563875ms)
Applied 1675269994/migrate add-sandbox-to-enum (1.580292ms)
Applied 1690000000/migrate TEST populate with duplicates (2.883791ms)
Applied 1695381202/migrate alter notifications constraint (3.4805ms)
Applied 9000000000/migrate TEST delete duplicates (3.79875ms)
```

As an optional step, we can log in to Postgres and check for the duplicates:

```
SELECT device_token, COUNT(*)
FROM clients
GROUP BY device_token
HAVING COUNT(*) > 1;
```

The expected result is that there are no duplicates in the `clients` table at the end of the migration (but they were populated by the test database [population migration script before](https://gist.github.com/geekbrother/72edfa9176263287c2e1626ae36df652)).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update