### PR TITLE
fix: updating device token deduplication SQL query in `create_client`

### DIFF
--- a/tests/functional/stores/client.rs
+++ b/tests/functional/stores/client.rs
@@ -61,55 +61,108 @@ async fn client_creation_apns(ctx: &mut StoreContext) {
 #[test_context(StoreContext)]
 #[tokio::test]
 async fn client_upsert_token(ctx: &mut StoreContext) {
-    let id = format!("id-{}", gen_id());
+    let client_id = format!("id-{}", gen_id());
     let token = format!("token-{}", gen_id());
 
     // Initial Client creation
     ctx.clients
-        .create_client(TENANT_ID, &id, Client {
+        .create_client(TENANT_ID, &client_id, Client {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Fcm,
             token: token.clone(),
         })
         .await
         .unwrap();
-    let insert_result = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
+    let insert_result = ctx.clients.get_client(TENANT_ID, &client_id).await.unwrap();
     assert_eq!(insert_result.token, token);
+
+    // Insert notification for the client to test the clients->notifications
+    // constraint works properly
+    let notification_id = format!("id-{}", gen_id());
+    let notification_payload = format!("payload-{}", gen_id());
+
+    ctx.notifications
+        .create_or_update_notification(
+            &notification_id,
+            TENANT_ID,
+            &client_id,
+            &echo_server::handlers::push_message::MessagePayload {
+                topic: String::new(),
+                flags: 0,
+                blob: notification_payload,
+            },
+        )
+        .await
+        .unwrap();
+    let get_notification_result = ctx
+        .notifications
+        .get_notification(&notification_id, TENANT_ID)
+        .await
+        .unwrap();
+    assert_eq!(get_notification_result.client_id, client_id);
 
     // Updating token for the same id
     let updated_token = format!("token-{}", gen_id());
     ctx.clients
-        .create_client(TENANT_ID, &id, Client {
+        .create_client(TENANT_ID, &client_id, Client {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Apns,
             token: updated_token.clone(),
         })
         .await
         .unwrap();
-    let updated_token_result = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
+    let updated_token_result = ctx.clients.get_client(TENANT_ID, &client_id).await.unwrap();
     assert_eq!(updated_token_result.token, updated_token);
 
     // Cleaning up records
-    ctx.clients.delete_client(TENANT_ID, &id).await.unwrap();
+    ctx.clients
+        .delete_client(TENANT_ID, &client_id)
+        .await
+        .unwrap();
 }
 
 #[test_context(StoreContext)]
 #[tokio::test]
 async fn client_upsert_id(ctx: &mut StoreContext) {
-    let id = format!("id-{}", gen_id());
+    let client_id = format!("id-{}", gen_id());
     let token = format!("token-{}", gen_id());
 
     // Initial Client creation
     ctx.clients
-        .create_client(TENANT_ID, &id, Client {
+        .create_client(TENANT_ID, &client_id, Client {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Fcm,
             token: token.clone(),
         })
         .await
         .unwrap();
-    let insert_result = ctx.clients.get_client(TENANT_ID, &id).await.unwrap();
+    let insert_result = ctx.clients.get_client(TENANT_ID, &client_id).await.unwrap();
     assert_eq!(insert_result.token, token.clone());
+
+    // Insert notification for the client to test the clients->notifications
+    // constraint works properly
+    let notification_id = format!("id-{}", gen_id());
+    let notification_payload = format!("payload-{}", gen_id());
+
+    ctx.notifications
+        .create_or_update_notification(
+            &notification_id,
+            TENANT_ID,
+            &client_id,
+            &echo_server::handlers::push_message::MessagePayload {
+                topic: String::new(),
+                flags: 0,
+                blob: notification_payload,
+            },
+        )
+        .await
+        .unwrap();
+    let get_notification_result = ctx
+        .notifications
+        .get_notification(&notification_id, TENANT_ID)
+        .await
+        .unwrap();
+    assert_eq!(get_notification_result.client_id, client_id);
 
     // Updating id for the same token
     let updated_id = gen_id();


### PR DESCRIPTION
# Description
This is a follow-up PR for #196 which was reverted by #209.

The issue was that the `clients.id -> notifications.client_id` constraint was missing during the changing of the SQL query in `create_client`.
The problem is resolved by the #211 so we can update the SQL query now.

Unit tests `client_upsert_token` and `client_upsert_id` were updated with notification inserting to check the constraint violation error (it was not checked at those tests before).

Resolves #193 

## How Has This Been Tested?

To run functional tests start the PostgreSQL instances:

```
docker run \
  -p 5432:5432 \
  -e POSTGRES_HOST_AUTH_METHOD=trust \
  --name echo-server-pg \
  -d postgres

docker run \
  -p 5433:5432 \
  -e POSTGRES_HOST_AUTH_METHOD=trust \
  --name echo-server-tenant-pg \
  -d postgres
```

Run the functional tests:

```
cargo t --features functional_tests
```

Two tests should fail with the constraint violation and the following errors:

```
---- functional::stores::client::client_upsert_id stdout ----
thread 'functional::stores::client::client_upsert_id' panicked at 'called `Result::unwrap()` on an `Err` value: Database(Database(PgDatabaseError { severity: Error, code: "23503", message: "update or delete on table \"clients\" violates foreign key constraint \"fk_notifications_client_id\" on table \"notifications\"", detail: Some("Key (id)=(id-a999985d-a7db-46a4-a809-1c6d30890ee0) is still referenced from table \"notifications\"."), hint: None, position: None, where: None, schema: Some("public"), table: Some("notifications"), column: None, data_type: None, constraint: Some("fk_notifications_client_id"), file: Some("ri_triggers.c"), line: Some(2621), routine: Some("ri_ReportViolation") }))', tests/functional/stores/client.rs:167:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- functional::stores::client::client_upsert_token stdout ----
thread 'functional::stores::client::client_upsert_token' panicked at 'called `Result::unwrap()` on an `Err` value: Database(Database(PgDatabaseError { severity: Error, code: "23503", message: "update or delete on table \"clients\" violates foreign key constraint \"fk_notifications_client_id\" on table \"notifications\"", detail: Some("Key (id)=(id-a4d5b2a1-67e3-4b09-8818-e662afc113a7) is still referenced from table \"notifications\"."), hint: None, position: None, where: None, schema: Some("public"), table: Some("notifications"), column: None, data_type: None, constraint: Some("fk_notifications_client_id"), file: Some("ri_triggers.c"), line: Some(2621), routine: Some("ri_ReportViolation") }))', tests/functional/stores/client.rs:110:10
```

We have a fix in #211 so cherry-pick changes from #211 by:

```
git cherry-pick d684c44
```

Re-run functional tests:

```
cargo t --features functional_tests
```

All tests should pass now demonstrating that the `foreign key constraint "fk_notifications_client_id" violation` error is fixed.

## Merging policy and dependency

This PR depends on and should be merged after #211

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update