### PR TITLE
fix: adding `id` for the updated release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update and commit the release version
+        id: release
         uses: WalletConnect/actions/github/update-rust-version/@2.1.4
         with:
           token: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
# Description

This PR fixing a nit: `id` for the updated `release` CI workflow script was missing causing the [following error when the release image is building](https://github.com/WalletConnect/echo-server/actions/runs/6318288511/job/17171976388#step:10:223):
```
RROR: tag is needed when pushing to registry
Error: buildx failed with: ERROR: tag is needed when pushing to registry
```

Resolves #199

## How Has This Been Tested?

Should be tested in the GitHub CI workflow running release action.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update