### PR TITLE
fix: don't wipe response_message

### DIFF
--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -100,7 +100,6 @@ pub async fn handler(
     #[cfg(feature = "analytics")]
     if let Some(mut message_info) = analytics_option {
         message_info.status = status;
-        message_info.response_message = None;
 
         tokio::spawn(async move {
             if let Some(analytics) = &state.analytics {


### PR DESCRIPTION
# Description

This was being set to `None` in all cases for some reason. This may be hiding some issues.

Resolves #215

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update