### PR TITLE
chore: extra assert APNS response is non-error

### DIFF
--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -358,7 +358,7 @@ pub async fn handler_internal(
     );
 
     match provider.send_notification(client.token, body.payload).await {
-        Ok(_) => Ok(()),
+        Ok(()) => Ok(()),
         Err(error) => match error {
             Error::BadDeviceToken => {
                 state

--- a/src/providers/apns.rs
+++ b/src/providers/apns.rs
@@ -102,8 +102,8 @@ impl PushProvider for ApnsProvider {
             Ok(response) => {
                 if response.error.is_some() {
                     warn!(
-                        "Unexpected APNS error. a2 lib shouldn't allow Ok result for error \
-                         response. Status: {} Error: {:?}",
+                        "Unexpected APNS error. a2 lib shouldn't allow returning Ok containing \
+                         error response. Status: {} Error: {:?}",
                         response.code, response.error
                     );
                     Err(Error::Apns(a2::Error::ResponseError(response)))


### PR DESCRIPTION
# Description

We are ignoring the response here as a result of poor interface design on the a2 library. While this shouldn't be an issue (I checked the a2 code) I want to assert the response is non-error anyway in-case we are hiding something.

Second, I changed `Ok(_)` to `Ok(())` to make it obvious we aren't ignoring anything.

Resolves #217

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update