### PR TITLE
chore: fixing output variable name in the `release` step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on:
       group: ubuntu-runners
     outputs:
-      version: ${{ steps.clean_version.outputs.version }}
+      version: ${{ steps.release.outputs.version }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
# Description

This PR fixes an output variable name for the `release` step resolving the `ERROR: tag is needed when pushing to registry` error while triggering the release.

Resolves #199

## How Has This Been Tested?

Validated by the GitHub actions fmt.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update