### PR TITLE
fix: `notification` variable is encoded as a string, fix alert thresholds

### DIFF
--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -592,7 +592,7 @@ resource "grafana_dashboard" "at_a_glance" {
             }
           ],
           "executionErrorState" : "alerting",
-          "frequency" : "5m",
+          "frequency" : "1m",
           "handler" : 1,
           "name" : "${var.environment} Echo Server 5XX alert",
           "noDataState" : "keep_state",

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -547,7 +547,7 @@ resource "grafana_dashboard" "at_a_glance" {
             {
               "evaluator" : {
                 "params" : [
-                  5
+                  1
                 ],
                 "type" : "gt"
               },
@@ -570,7 +570,7 @@ resource "grafana_dashboard" "at_a_glance" {
             {
               "evaluator" : {
                 "params" : [
-                  5
+                  1
                 ],
                 "type" : "gt"
               },
@@ -592,12 +592,11 @@ resource "grafana_dashboard" "at_a_glance" {
             }
           ],
           "executionErrorState" : "alerting",
-          "for" : "5m",
-          "frequency" : "1m",
+          "frequency" : "5m",
           "handler" : 1,
           "name" : "${var.environment} Echo Server 5XX alert",
-          "noDataState" : "no_data",
-          "notifications" : jsonencode(local.notifications)
+          "noDataState" : "keep_state",
+          "notifications" : local.notifications
         },
         "datasource" : {
           "type" : "cloudwatch",


### PR DESCRIPTION
# Description

This PR fixes firing alerts for 5xx errors by making the following changes:
- Removing `jsonencode` from the local `notifications` variable that causes encoding json array as a string.
- Changing evaluation for the 5xx errors for every 5 minutes with 0 threshold. In this case, we can catch 500 errors even when the error appears and then disappears, so we can investigate it.
- Changing the threshold for an error count from 5 to 1 so we can catch and investigate a single 500 errors if they occur.
- Changing the policy for `no data state` from: `no_data` to keep the last state to provide consistent alarm firing in case the threshold was met and then no data was provided.

Resolves #210

## How Has This Been Tested?

Deployed from the PR branch to the staging environment, the alert was fired successfully and delivered to the opsgenie and slack channel when the 500 error count was > 1 for 5 minutes.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update