### PR TITLE
fix: changing client creation SQL query to handle id and token non-unique

### DIFF
--- a/src/stores/client.rs
+++ b/src/stores/client.rs
@@ -33,11 +33,15 @@ impl ClientStore for sqlx::PgPool {
 
         let mut transaction = self.begin().await?;
 
-        sqlx::query("DELETE FROM public.clients WHERE id = $1 OR device_token = $2")
-            .bind(id)
-            .bind(client.token.clone())
-            .execute(&mut transaction)
-            .await?;
+        sqlx::query(
+            "DELETE FROM public.clients \
+            WHERE id = $1 OR device_token = $2 \
+            OR (id = $1 AND device_token = $2)",
+        )
+        .bind(id)
+        .bind(client.token.clone())
+        .execute(&mut transaction)
+        .await?;
 
         let mut insert_query = sqlx::QueryBuilder::new(
             "INSERT INTO public.clients (id, tenant_id, push_type, device_token)",


### PR DESCRIPTION
# Description

This PR changes the SQL query in the client creation to handle behavior when the client tries to register with the same client id and device token as it has (they both are non-unique). This change fixes throwing 500 errors when this case happens.

Resolves #230 

## How Has This Been Tested?

It's covered by the functional unit tests for the client creation. The expected behavior is passing the CI gate.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update