### PR TITLE
test: adding `client_create_same_id_and_token` test

### DIFF
--- a/tests/functional/stores/client.rs
+++ b/tests/functional/stores/client.rs
@@ -190,6 +190,70 @@ async fn client_upsert_id(ctx: &mut StoreContext) {
 
 #[test_context(StoreContext)]
 #[tokio::test]
+async fn client_create_same_id_and_token(ctx: &mut StoreContext) {
+    let client_id = format!("id-{}", gen_id());
+    let token = format!("token-{}", gen_id());
+
+    // Initial Client creation
+    ctx.clients
+        .create_client(TENANT_ID, &client_id, Client {
+            tenant_id: TENANT_ID.to_string(),
+            push_type: ProviderKind::Fcm,
+            token: token.clone(),
+        })
+        .await
+        .unwrap();
+    let insert_result = ctx.clients.get_client(TENANT_ID, &client_id).await.unwrap();
+    assert_eq!(insert_result.token, token.clone());
+
+    // Insert notification for the client to test the clients->notifications
+    // constraint works properly
+    let notification_id = format!("id-{}", gen_id());
+    let notification_payload = format!("payload-{}", gen_id());
+
+    ctx.notifications
+        .create_or_update_notification(
+            &notification_id,
+            TENANT_ID,
+            &client_id,
+            &echo_server::handlers::push_message::MessagePayload {
+                topic: String::new(),
+                flags: 0,
+                blob: notification_payload,
+            },
+        )
+        .await
+        .unwrap();
+    let get_notification_result = ctx
+        .notifications
+        .get_notification(&notification_id, TENANT_ID)
+        .await
+        .unwrap();
+    assert_eq!(get_notification_result.client_id, client_id);
+
+    // Create a Client with the same id and same device token
+    // changing only the push_type to check if it was upserted
+    ctx.clients
+        .create_client(TENANT_ID, &client_id, Client {
+            tenant_id: TENANT_ID.to_string(),
+            push_type: ProviderKind::Noop,
+            token: token.clone(),
+        })
+        .await
+        .unwrap();
+    let double_insert_result = ctx.clients.get_client(TENANT_ID, &client_id).await.unwrap();
+    assert_eq!(double_insert_result.token, token);
+    assert_eq!(double_insert_result.push_type, ProviderKind::Noop);
+
+    // Cleaning up records
+    ctx.clients
+        .delete_client(TENANT_ID, &client_id)
+        .await
+        .unwrap();
+}
+
+#[test_context(StoreContext)]
+#[tokio::test]
 async fn client_deletion(ctx: &mut StoreContext) {
     let id = format!("id-{}", gen_id());
     let token = format!("token-{}", gen_id());


### PR DESCRIPTION
# Description

Adding the `client_create_same_id_and_token` functional test for the test client creation with the same `id` and `device_token` which are already present in the database.

Related to #230 

## How Has This Been Tested?

Covered by the CI Unit tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update