### PR TITLE
fix: use `axum-client-ip` to get the real client IP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,7 +1187,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "echo-server"
-version = "0.34.7"
+version = "0.35.0"
 dependencies = [
  "a2",
  "async-recursion",
@@ -1196,6 +1196,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "axum",
+ "axum-client-ip",
  "base64 0.21.4",
  "build-info",
  "build-info-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ wc = { git = "https://github.com/WalletConnect/utils-rs.git", tag = "v0.5.1", fe
 
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.6", features = ["json", "multipart", "tokio"] }
+axum-client-ip = "0.4"
 tower = "0.4"
 tower-http = { version = "0.4", features = ["trace", "cors", "request-id", "propagate-header", "catch-panic"] }
 hyper = "0.14"

--- a/src/handlers/single_tenant_wrappers.rs
+++ b/src/handlers/single_tenant_wrappers.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "analytics")]
+use axum_client_ip::SecureClientIp;
 use {
     crate::{
         error::Result,
@@ -13,8 +15,6 @@ use {
     hyper::HeaderMap,
     std::sync::Arc,
 };
-#[cfg(feature = "analytics")]
-use {axum::extract::ConnectInfo, std::net::SocketAddr};
 
 #[cfg(feature = "multitenant")]
 use crate::error::Error::MissingTenantId;
@@ -37,7 +37,7 @@ pub async fn delete_handler(
 }
 
 pub async fn push_handler(
-    #[cfg(feature = "analytics")] addr: ConnectInfo<SocketAddr>,
+    #[cfg(feature = "analytics")] SecureClientIp(client_ip): SecureClientIp,
     Path(id): Path<String>,
     state: StateExtractor<Arc<AppState>>,
     headers: HeaderMap,
@@ -48,7 +48,7 @@ pub async fn push_handler(
 
     #[cfg(all(not(feature = "multitenant"), feature = "analytics"))]
     return crate::handlers::push_message::handler(
-        addr,
+        SecureClientIp(client_ip),
         Path((DEFAULT_TENANT_ID.to_string(), id)),
         state,
         headers,
@@ -67,7 +67,7 @@ pub async fn push_handler(
 }
 
 pub async fn register_handler(
-    #[cfg(feature = "analytics")] addr: ConnectInfo<SocketAddr>,
+    #[cfg(feature = "analytics")] SecureClientIp(client_ip): SecureClientIp,
     state: StateExtractor<Arc<AppState>>,
     headers: HeaderMap,
     body: Json<RegisterBody>,
@@ -77,7 +77,7 @@ pub async fn register_handler(
 
     #[cfg(all(not(feature = "multitenant"), feature = "analytics"))]
     return crate::handlers::register_client::handler(
-        addr,
+        SecureClientIp(client_ip),
         Path(DEFAULT_TENANT_ID.to_string()),
         state,
         headers,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ use {
         routing::{delete, get, post},
         Router,
     },
+    axum_client_ip::SecureClientIpSource,
     config::Config,
     hyper::http::Method,
     opentelemetry::{sdk::Resource, KeyValue},
@@ -210,7 +211,8 @@ pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Config) -> 
                     hyper::http::header::CONTENT_TYPE,
                     hyper::http::header::AUTHORIZATION,
                 ]),
-        );
+        )
+        .layer(SecureClientIpSource::RightmostXForwardedFor.into_extension());
 
     #[cfg(feature = "multitenant")]
     let app = {


### PR DESCRIPTION
# Description

This PR adds using of `axum-client-ip` to get a real client IP which is included in the `X-Forwarded` by calling `SecureClientIp`. The AWS ELB[ uses X-Forwarded-for](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html) and [SecureClientIp sourced it for a real IP](https://github.com/imbolc/axum-client-ip/blob/a23f172ee4d01ead9ec25cedd3e6359ba63a03ad/src/secure.rs#L33).

Following changes are made:
 - `axum-client-ip` is added to the `Cargo.toml` as a dependency. We [already have it](https://github.com/WalletConnect/echo-server/blob/46d17972c3f83288fd849ca4c16ad15edb11caee/Cargo.lock#L607) as a relative dependency in the `Cargo.lock` so it will not add additional dependency weight.
 - `ConnectInfo` replaced with `SecureClientIp`.

Resolves #225

## How Has This Been Tested?

Successfully built and run with `analytics` feature enabled.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update