### PR TITLE
fix: spacing fix in the terraform main file

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -178,7 +178,7 @@ module "ecs" {
   cloud_api_key = var.cloud_api_key
   cloud_api_url = "https://registry.walletconnect.com/"
 
-  jwt_secret = var.jwt_secret
+  jwt_secret       = var.jwt_secret
   relay_public_key = var.relay_public_key
 
   autoscaling_max_capacity = local.environment == "prod" ? 4 : 1


### PR DESCRIPTION
# Description

This is a spacing fix for the `main.cf` from #241 

Resolves #228 

## How Has This Been Tested?

Tested by the CI terraform fmt workflow.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update