### PR TITLE
fix: fixing apns keys encoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
       DATABASE_URL: postgres://postgres:root@localhost:5432/postgres
       TENANT_DATABASE_URL: postgres://postgres:root@localhost:5433/postgres
       RELAY_PUBLIC_KEY: ${{ secrets.RELAY_PUBLIC_KEY }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
     steps:
       # Checkout code
       - name: "Git checkout"
@@ -155,6 +156,9 @@ jobs:
           args: ${{ matrix.cargo.args }}
         env:
           ECHO_TEST_FCM_KEY: ${{ secrets.ECHO_TEST_FCM_KEY }}
+          ECHO_TEST_APNS_P8_KEY_ID: ${{ secrets.ECHO_TEST_APNS_P8_KEY_ID }}
+          ECHO_TEST_APNS_P8_TEAM_ID: ${{ secrets.ECHO_TEST_APNS_P8_TEAM_ID }}
+          ECHO_TEST_APNS_P8_PEM: ${{ secrets.ECHO_TEST_APNS_P8_PEM }}
 
       - name: "Print sccache stats"
         run: sccache --show-stats

--- a/src/handlers/get_tenant.rs
+++ b/src/handlers/get_tenant.rs
@@ -13,11 +13,11 @@ use {
         http::HeaderMap,
         Json,
     },
-    serde::Serialize,
+    serde::{Deserialize, Serialize},
     std::sync::Arc,
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetTenantResponse {
     url: String,
     enabled_providers: Vec<String>,

--- a/src/stores/tenant.rs
+++ b/src/stores/tenant.rs
@@ -218,10 +218,7 @@ impl Tenant {
                         &self.apns_team_id,
                     ) {
                         (Some(topic), Some(pkcs8_pem), Some(key_id), Some(team_id)) => {
-                            let decoded =
-                                base64::engine::general_purpose::STANDARD.decode(pkcs8_pem)?;
-                            let mut reader = BufReader::new(&*decoded);
-
+                            let mut reader = BufReader::new(pkcs8_pem.as_bytes());
                             let apns_client = ApnsProvider::new_token(
                                 &mut reader,
                                 key_id.clone(),

--- a/tests/context/mod.rs
+++ b/tests/context/mod.rs
@@ -19,6 +19,7 @@ pub struct ConfigContext {
 
 pub struct EchoServerContext {
     pub server: EchoServer,
+    pub config: Config,
 }
 
 pub struct StoreContext {
@@ -41,8 +42,10 @@ impl TestContext for ConfigContext {
             disable_header: true,
             validate_signatures: false,
             relay_public_key: env::var("RELAY_PUBLIC_KEY").unwrap_or("none".to_string()),
-            database_url: env::var("DATABASE_URL").unwrap(),
-            tenant_database_url: env::var("TENANT_DATABASE_URL").unwrap(),
+            database_url: env::var("DATABASE_URL")
+                .expect("DATABASE_URL environment variable is not set"),
+            tenant_database_url: env::var("TENANT_DATABASE_URL")
+                .expect("TENANT_DATABASE_URL environment variable is not set"),
             #[cfg(feature = "multitenant")]
             jwt_secret: "n/a".to_string(),
             otel_exporter_otlp_endpoint: None,
@@ -87,8 +90,9 @@ impl TestContext for ConfigContext {
 #[async_trait]
 impl AsyncTestContext for EchoServerContext {
     async fn setup() -> Self {
+        let config = ConfigContext::setup().config;
         let server = EchoServer::start(ConfigContext::setup().config).await;
-        Self { server }
+        Self { server, config }
     }
 }
 

--- a/tests/functional/multitenant/apns.rs
+++ b/tests/functional/multitenant/apns.rs
@@ -1,9 +1,22 @@
 use {
     crate::context::EchoServerContext,
-    echo_server::handlers::create_tenant::TenantRegisterBody,
+    echo_server::handlers::{create_tenant::TenantRegisterBody, get_tenant::GetTenantResponse},
+    jsonwebtoken::{encode, EncodingKey, Header},
     random_string::generate,
+    serde::Serialize,
+    std::time::SystemTime,
     test_context::test_context,
+    uuid::Uuid,
 };
+
+/// Struct to hold claims for JWT validation
+#[derive(Serialize)]
+struct ClaimsForValidation {
+    sub: String,
+    aud: String,
+    role: String,
+    exp: usize,
+}
 
 // #[test_context(EchoServerContext)]
 // #[tokio::test]
@@ -43,6 +56,66 @@ use {
 //         "Response was not successful"
 //     );
 // }
+
+#[test_context(EchoServerContext)]
+#[tokio::test]
+async fn tenant_update_apns_valid_token(ctx: &mut EchoServerContext) {
+    let tenant_id = Uuid::new_v4().to_string();
+    let payload = TenantRegisterBody {
+        id: tenant_id.clone(),
+    };
+    let unix_timestamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as usize;
+    let token_claims = ClaimsForValidation {
+        sub: tenant_id.clone(),
+        aud: "authenticated".to_string(),
+        role: "authenticated".to_string(),
+        exp: unix_timestamp + 60 * 60, // Add an hour for expiration
+    };
+    let jwt_token = encode(
+        &Header::default(),
+        &token_claims,
+        &EncodingKey::from_secret(ctx.config.jwt_secret.as_bytes()),
+    )
+    .expect("Failed to encode jwt token");
+
+    // Register new tenant
+    let client = reqwest::Client::new();
+    let create_tenant_result = client
+        .post(format!("http://{}/tenants", ctx.server.public_addr))
+        .header("AUTHORIZATION", jwt_token.clone())
+        .json(&payload)
+        .send()
+        .await
+        .expect("Failed to create a new tenant");
+    assert_eq!(create_tenant_result.status(), reqwest::StatusCode::OK);
+
+    // Send valid APNS p8 Key
+    let form = reqwest::multipart::Form::new()
+        .text("apns_type", "token")
+        .text("apns_topic", "app.test")
+        .text("apns_key_id", env!("ECHO_TEST_APNS_P8_KEY_ID"))
+        .text("apns_team_id", env!("ECHO_TEST_APNS_P8_TEAM_ID"))
+        .part(
+            "apns_pkcs8_pem",
+            reqwest::multipart::Part::text(env!("ECHO_TEST_APNS_P8_PEM"))
+                .file_name("apns.p8")
+                .mime_str("text/plain")
+                .expect("Error on passing multipart stream to the form request"),
+        );
+    let apns_update_result = client
+        .post(format!(
+            "http://{}/tenants/{}/apns",
+            ctx.server.public_addr, &tenant_id
+        ))
+        .multipart(form)
+        .send()
+        .await
+        .expect("Failed to call update tenant endpoint");
+    assert_eq!(apns_update_result.status(), reqwest::StatusCode::OK);
+}
 
 #[test_context(EchoServerContext)]
 #[tokio::test]


### PR DESCRIPTION
# Description

To fix the multi-tenant apns update bug (where apns key is always wrong), the following changes and fixes are made:

Commit [163155f](https://github.com/WalletConnect/echo-server/pull/246/commits/163155f77eea6892f1f2424c32093b9623a2b388) fix:
- Removing [base64 encoding from the p8 ke](https://github.com/WalletConnect/echo-server/blob/80e3bf5c7ab5537c31bbe2c034f805e77f368ef8/src/handlers/update_apns.rs#L140)y as it's in already base64 key format (PEM),
- Added [missed decoding from base64 for the p12 key](https://github.com/WalletConnect/echo-server/blob/80e3bf5c7ab5537c31bbe2c034f805e77f368ef8/src/handlers/update_apns.rs#L182-L196),
- Adding values extraction case when the password is not provided (key without password), as [it was missed](https://github.com/WalletConnect/echo-server/blob/80e3bf5c7ab5537c31bbe2c034f805e77f368ef8/src/handlers/update_apns.rs#L51-L95) and always returning `Invalid Multipart Body` when the password was not provided,
- Replacing `BufReader` with `Cursor` as we don't need to create a buffer and can use just a cursor.

Commit [917c36a](https://github.com/WalletConnect/echo-server/pull/246/commits/917c36aa3b5898477cbf732ccf1c900027068335) test:
- Functional unit test `tenant_update_apns_valid_token` was created to cover testing apns update using the `reqwest` post request with the multipart form with valid apns p8 key from the environment variable,
- Adding required CI variables passing to run `tenant_update_apns_valid_token` unit test with valid apns p8 key from GitHub secrets.

Resolves #244 

## How Has This Been Tested?

It was tested by the CI unit test `tenant_update_apns_valid_token` from this PR.
The expected behavior is passing the `tenant_update_apns_valid_token` from the CI gate.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update