### PR TITLE
chore: fix tenant ID log

### DIFF
--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -133,7 +133,7 @@ pub async fn handler(
     Ok(response)
 }
 
-#[instrument(skip_all, fields(tenant_id, client_id = id, id = body.id))]
+#[instrument(name = "push_message_internal", skip_all, fields(tenant_id = tenant_id, client_id = id, id = body.id))]
 pub async fn handler_internal(
     Path((tenant_id, id)): Path<(String, String)>,
     StateExtractor(state): StateExtractor<Arc<AppState>>,


### PR DESCRIPTION
# Description

Before `tenant_id` was only logged if calling `tracing::Span::current().record()`. Fixed that.

Also rename the span to make it more identifiable.

Resolves #254

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update