### PR TITLE
chore: distinguish bad device token errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,8 +25,8 @@ pub enum Error {
     #[error(transparent)]
     Prometheus(#[from] prometheus_core::Error),
 
-    #[error("invalid device token provided")]
-    BadDeviceToken,
+    #[error("Bad device token error: {0}")]
+    BadDeviceToken(String),
 
     #[error(transparent)]
     Apns(#[from] a2::Error),
@@ -186,10 +186,10 @@ impl IntoResponse for Error {
     fn into_response(self) -> Response {
         warn!("responding with error: {self:?}");
         let response = match &self {
-            Error::BadDeviceToken => crate::handlers::Response::new_failure(StatusCode::BAD_REQUEST, vec![
+            Error::BadDeviceToken(e) => crate::handlers::Response::new_failure(StatusCode::BAD_REQUEST, vec![
                 ResponseError {
                     name: "invalid_token".to_string(),
-                    message: "Provided device token is now invalid, the client id has been un-registered".to_string(),
+                    message: e.to_string(),
                 }
             ], vec![
                 ErrorField {

--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -369,7 +369,7 @@ pub async fn handler_internal(
         Err(error) => {
             warn!("error sending notification: {error:?}");
             match error {
-                Error::BadDeviceToken => {
+                Error::BadDeviceToken(_) => {
                     state
                         .client_store
                         .delete_client(&tenant_id, &id)

--- a/src/providers/apns.rs
+++ b/src/providers/apns.rs
@@ -115,10 +115,17 @@ impl PushProvider for ApnsProvider {
                 a2::Error::ResponseError(res) => match res.error {
                     None => Err(Error::Apns(a2::Error::ResponseError(res))),
                     Some(response) => match response.reason {
-                        ErrorReason::BadDeviceToken => Err(Error::BadDeviceToken),
+                        ErrorReason::BadDeviceToken => {
+                            Err(Error::BadDeviceToken("Bad device token".to_string()))
+                        }
                         // Note: This will have the device deleted because the token was not for the
                         // configured topic
-                        ErrorReason::DeviceTokenNotForTopic => Err(Error::BadDeviceToken),
+                        ErrorReason::DeviceTokenNotForTopic => Err(Error::BadDeviceToken(
+                            "The device token does not match the specified topic".to_string(),
+                        )),
+                        ErrorReason::Unregistered => Err(Error::BadDeviceToken(
+                            "The device token is inactive for the specified topic".to_string(),
+                        )),
                         reason => Err(Error::ApnsResponse(reason)),
                     },
                 },

--- a/src/providers/fcm.rs
+++ b/src/providers/fcm.rs
@@ -70,9 +70,15 @@ impl PushProvider for FcmProvider {
                 let FcmResponse { error, .. } = val;
                 if let Some(error) = error {
                     match error {
-                        ErrorReason::MissingRegistration
-                        | ErrorReason::InvalidRegistration
-                        | ErrorReason::NotRegistered => Err(Error::BadDeviceToken),
+                        ErrorReason::MissingRegistration => Err(Error::BadDeviceToken(
+                            "Missing registration for token".into(),
+                        )),
+                        ErrorReason::InvalidRegistration => {
+                            Err(Error::BadDeviceToken("Invalid token registration".into()))
+                        }
+                        ErrorReason::NotRegistered => {
+                            Err(Error::BadDeviceToken("Token is not registered".into()))
+                        }
                         ErrorReason::InvalidApnsCredential => Err(Error::BadApnsCredentials),
                         e => Err(Error::FcmResponse(e)),
                     }


### PR DESCRIPTION
# Description

We have a lot of `apns(unregistered)` HTTP 500 errors. An `unregistered device token` is not an internal server error and should be distinguished from it. `BadDeviceToken` error should be used for such cases.

1. This PR changes the `BadDeviceToken` error type to have a string argument that reflects a certain device token error.
2. Distinguish apns and fcm responses from bad device tokens and other types that should throw 500 (Internal Server Error).

Resolves #256 

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update