### PR TITLE
chore: adding `for` and `message` for 5xx alerts

### DIFF
--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -593,9 +593,11 @@ resource "grafana_dashboard" "at_a_glance" {
           ],
           "executionErrorState" : "alerting",
           "frequency" : "1m",
+          "for" : "5m",
           "handler" : 1,
           "name" : "${var.environment} Echo Server 5XX alert",
           "noDataState" : "keep_state",
+          "message" : "Echo server - Prod - 5XX error",
           "notifications" : local.notifications
         },
         "datasource" : {


### PR DESCRIPTION
# Description

This PR adds missing `for` and `message` fields for the `panels` -> `alert` scope in grafana.

Resolves #210 

## How Has This Been Tested?

Tested in the Grafana dashboard by putting these in the builder and checking the JSON after.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update