### PR TITLE
chore: change no data state for 5xx monitoring

### DIFF
--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -596,7 +596,7 @@ resource "grafana_dashboard" "at_a_glance" {
           "for" : "5m",
           "handler" : 1,
           "name" : "${var.environment} Echo Server 5XX alert",
-          "noDataState" : "keep_state",
+          "noDataState" : "no_data",
           "message" : "Echo server - Prod - 5XX error",
           "notifications" : local.notifications
         },


### PR DESCRIPTION
# Description

This PR changes the state to the `no data` for the 5xx alert rule from the `last state`.
When there are no 5xx errors we don't have any new data so keeping the last state after we have a 5xx error makes the alerting state persist even after there are no errors. Switching to `no data` should fix this behavior.

Resolves #210

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update