### PR TITLE
fix: remove `for` from evaluation and adding a threshold line

### DIFF
--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -593,7 +593,7 @@ resource "grafana_dashboard" "at_a_glance" {
           ],
           "executionErrorState" : "alerting",
           "frequency" : "1m",
-          "for" : "5m",
+          "for" : "",
           "handler" : 1,
           "name" : "${var.environment} Echo Server 5XX alert",
           "noDataState" : "no_data",
@@ -619,7 +619,8 @@ resource "grafana_dashboard" "at_a_glance" {
               "hideFrom" : {
                 "legend" : false,
                 "tooltip" : false,
-                "viz" : false
+                "viz" : false,
+                "mode" : "dashed",
               },
               "lineInterpolation" : "linear",
               "lineWidth" : 1,
@@ -718,6 +719,14 @@ resource "grafana_dashboard" "at_a_glance" {
             "region" : "default",
             "sqlExpression" : "",
             "statistic" : "Sum"
+          }
+        ],
+        "thresholds" : [
+          {
+            "colorMode" : "critical",
+            "op" : "gt",
+            "value" : 1,
+            "visible" : true
           }
         ],
         "title" : "5XX",


### PR DESCRIPTION
# Description

This PR adds changes for the Grafana alert rule and 5xx Errors dashboard:
- Removing 5xx alert evaluation for 5 minutes, because we will miss alerts when the 5xx error occurs not constantly (less than 5 minutes constantly) and we want to catch every 5xx.
- Adding a red line dotted threshold for the 5xx Errors Dashboard in Grafana configuration.

Resolves #210

## How Has This Been Tested?

Tested by pushing the json config to the Grafana dashboard.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update