### PR TITLE
fix: adding jwt verification to the apns and fcm update handler

### DIFF
--- a/tests/functional/multitenant/apns.rs
+++ b/tests/functional/multitenant/apns.rs
@@ -61,6 +61,7 @@ async fn tenant_update_apns_valid_token(ctx: &mut EchoServerContext) {
             "http://{}/tenants/{}/apns",
             ctx.server.public_addr, &tenant_id
         ))
+        .header("AUTHORIZATION", jwt_token.clone())
         .multipart(form)
         .send()
         .await


### PR DESCRIPTION
# Description

This PR adds missing JWT verification to the:
- update apns handler,
- update fcm handler.

Resolves #262

## How Has This Been Tested?

Functional tests for valid apns and fcm update [fails without providing jwt](https://github.com/WalletConnect/echo-server/actions/runs/6598301402/job/17926141443?pr=261#step:11:871).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update