### PR TITLE
fix: fixing and enabling ignored tests

### DIFF
--- a/tests/functional/multitenant/apns.rs
+++ b/tests/functional/multitenant/apns.rs
@@ -1,61 +1,12 @@
 use {
-    crate::context::EchoServerContext,
-    echo_server::handlers::{create_tenant::TenantRegisterBody, get_tenant::GetTenantResponse},
+    crate::{context::EchoServerContext, functional::multitenant::ClaimsForValidation},
+    echo_server::handlers::create_tenant::TenantRegisterBody,
     jsonwebtoken::{encode, EncodingKey, Header},
     random_string::generate,
-    serde::Serialize,
     std::time::SystemTime,
     test_context::test_context,
     uuid::Uuid,
 };
-
-/// Struct to hold claims for JWT validation
-#[derive(Serialize)]
-struct ClaimsForValidation {
-    sub: String,
-    aud: String,
-    role: String,
-    exp: usize,
-}
-
-// #[test_context(EchoServerContext)]
-// #[tokio::test]
-// async fn tenant_update_apns(ctx: &mut EchoServerContext) {
-//     let charset = "1234567890";
-//     let random_tenant_id = generate(12, charset);
-//     let payload = TenantRegisterBody {
-//         id: random_tenant_id.clone(),
-//     };
-//
-//     // Register tenant
-//     let client = reqwest::Client::new();
-//     let response = client
-//         .post(format!("http://{}/tenants", ctx.server.public_addr))
-//         .json(&payload)
-//         .send()
-//         .await
-//         .expect("Call failed");
-//
-//     // Send valid token/cert
-//     // TODO figure out how to get valid creds into test!
-//     let api_key = env!("ECHO_TEST_FCM_KEY");
-//     let form = reqwest::multipart::Form::new().text("api_key", api_key);
-//
-//     let response = client
-//         .post(format!(
-//             "http://{}/tenants/{}/apns",
-//             ctx.server.public_addr, &random_tenant_id
-//         ))
-//         .multipart(form)
-//         .send()
-//         .await
-//         .expect("Call failed");
-//
-//     assert!(
-//         response.status().is_success(),
-//         "Response was not successful"
-//     );
-// }
 
 #[test_context(EchoServerContext)]
 #[tokio::test]

--- a/tests/functional/multitenant/fcm.rs
+++ b/tests/functional/multitenant/fcm.rs
@@ -1,48 +1,63 @@
 use {
-    crate::context::EchoServerContext,
+    crate::{context::EchoServerContext, functional::multitenant::ClaimsForValidation},
     echo_server::handlers::create_tenant::TenantRegisterBody,
+    jsonwebtoken::{encode, EncodingKey, Header},
     random_string::generate,
+    std::time::SystemTime,
     test_context::test_context,
 };
 
 #[test_context(EchoServerContext)]
 #[tokio::test]
-// This test is unexpectedly failing and ignored until the resolution
-#[ignore]
-async fn tenant_update_fcm(ctx: &mut EchoServerContext) {
+async fn tenant_update_fcm_valid(ctx: &mut EchoServerContext) {
     let charset = "1234567890";
     let random_tenant_id = generate(12, charset);
     let payload = TenantRegisterBody {
         id: random_tenant_id.clone(),
     };
+    let unix_timestamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as usize;
+    let token_claims = ClaimsForValidation {
+        sub: random_tenant_id.clone(),
+        aud: "authenticated".to_string(),
+        role: "authenticated".to_string(),
+        exp: unix_timestamp + 60 * 60, // Add an hour for expiration
+    };
+    let jwt_token = encode(
+        &Header::default(),
+        &token_claims,
+        &EncodingKey::from_secret(ctx.config.jwt_secret.as_bytes()),
+    )
+    .expect("Failed to encode jwt token");
 
     // Register tenant
     let client = reqwest::Client::new();
-    client
+    let register_response = client
         .post(format!("http://{}/tenants", ctx.server.public_addr))
         .json(&payload)
+        .header("AUTHORIZATION", jwt_token.clone())
         .send()
         .await
         .expect("Call failed");
+    assert_eq!(register_response.status(), reqwest::StatusCode::OK);
 
     // Send valid API Key
     let api_key = env!("ECHO_TEST_FCM_KEY");
     let form = reqwest::multipart::Form::new().text("api_key", api_key);
 
-    let response = client
+    let response_fcm_update = client
         .post(format!(
             "http://{}/tenants/{}/fcm",
             ctx.server.public_addr, &random_tenant_id
         ))
+        .header("AUTHORIZATION", jwt_token.clone())
         .multipart(form)
         .send()
         .await
         .expect("Call failed");
-
-    assert!(
-        response.status().is_success(),
-        "Response was not successful"
-    );
+    assert_eq!(response_fcm_update.status(), reqwest::StatusCode::OK);
 }
 
 #[test_context(EchoServerContext)]

--- a/tests/functional/multitenant/mod.rs
+++ b/tests/functional/multitenant/mod.rs
@@ -1,9 +1,18 @@
 /// Tests against the handlers
-use {crate::context::EchoServerContext, test_context::test_context};
+use {crate::context::EchoServerContext, serde::Serialize, test_context::test_context};
 
 mod apns;
 mod fcm;
 mod tenancy;
+
+/// Struct to hold claims for JWT validation
+#[derive(Serialize)]
+pub struct ClaimsForValidation {
+    sub: String,
+    aud: String,
+    role: String,
+    exp: usize,
+}
 
 #[test_context(EchoServerContext)]
 #[tokio::test]


### PR DESCRIPTION
# Description

Fixing for running and removing ignore for the following tests:
- Updating fcm with the valid API key,
- Register, get, and delete new tenants.

Resolves #264 

## How Has This Been Tested?

Tests are run by the CI unit tests workflow and passing it:
- [tenant_update_fcm_valid](https://github.com/WalletConnect/echo-server/actions/runs/6611285586/job/17957940496?pr=263#step:11:863),
- [tenant_register_get_delete](https://github.com/WalletConnect/echo-server/actions/runs/6611285586/job/17957940496?pr=263#step:11:861).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update