### PR TITLE
chore(version): v0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 - - -
+## v0.35.1 - 2023-11-06
+#### Bug Fixes
+- adding jwt verification to the apns and fcm update handler (#261) - (2c454eb) - Max Kalashnikoff
+- fixing and enabling ignored tests (#263) - (7bf555a) - Max Kalashnikoff
+- remove `for` from evaluation and adding a threshold line (#260) - (a070782) - Max Kalashnikoff
+- `notification` variable is encoded as a string, fix alert thresholds (#231) - (8028744) - Max Kalashnikoff
+- revert to the base64 encoded p8 key (#253) - (0339004) - Max Kalashnikoff
+- fixing apns keys encoding (#246) - (2e6a9fe) - Max Kalashnikoff
+- spacing fix in the terraform main file (#243) - (9d37d66) - Max Kalashnikoff
+- using relay public key from environment variable (#241) - (0934fd2) - Max Kalashnikoff
+- use `axum-client-ip` to get the real client IP (#240) - (591effe) - Max Kalashnikoff
+- add advisory locking to the client create (#239) - (46d1797) - Max Kalashnikoff
+- adding `... FOR UPDATE` to lock the row while client creation (#235) - (1de1a69) - Max Kalashnikoff
+#### Continuous Integration
+- bump `update_rust_version` to 2.1.5 (#237) - (066bd18) - Max Kalashnikoff
+#### Miscellaneous Chores
+- update `utils` version (#269) - (5695fa3) - Xavier Basty
+- remove Ukraine from list of OFAC blocked countries (#268) - (a8b467a) - Xavier Basty
+- add Russia and Ukraine to list of OFAC blocked countries (#336) (#266) - (e7344b1) - Xavier Basty
+- change no data state for 5xx monitoring (#259) - (190a1ed) - Max Kalashnikoff
+- distinguish bad device token errors (#257) - (733c152) - Max Kalashnikoff
+- fix tenant ID log (#255) - (3902a9c) - Chris Smith
+- adding `for` and `message` for 5xx alerts (#258) - (3acf35a) - Max Kalashnikoff
+- tap err (#252) - (bbdf178) - Chris Smith
+- distinguish 500s from other errors (#248) - (b1135ce) - Chris Smith
+- more logging (#250) - (45902c7) - Chris Smith
+- adding logs to apns update (#245) - (80e3bf5) - Max Kalashnikoff
+- deploy to production became optional with choice for the `image_tag` (#226) - (3b10917) - Max Kalashnikoff
+#### Tests
+- adding `client_create_same_id_and_token` test (#234) - (c7b14ff) - Max Kalashnikoff
+
+- - -
+
 ## v0.35.0 - 2023-10-02
 #### Features
 - geo-blocking, replace `gorgon` with `utils-rs` (#227) - (40e6d51) - Xavier Basty

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,7 +1187,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "echo-server"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "a2",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-server"
-version = "0.35.0"
+version = "0.35.1"
 edition = "2021"
 authors = [
     "Harry Bairstow <harry@walletconnect.com>"


### PR DESCRIPTION
# Description

Manually bumping the release, because [3dde225](https://github.com/WalletConnect/echo-server/commit/3dde225228178c6198c89d674113c05ad4eb700b) commit was merged without conventional commits prefix. [cog check](https://github.com/WalletConnect/actions/blob/685dc89e63da7151f9addb3106c524f0a6079431/github/update-rust-version/action.yml#L20-L22) is failing in our shared `update-rust-version` workflow because of that ([exact error](https://github.com/WalletConnect/echo-server/actions/runs/6423693757/job/17442725460#step:5:61)).

Manually bumping the release skipping the unconventional commit to solve this issue.
New release `0.35.1` and new tag `0.35.1` should be created after merging this PR.

Resolves #270 

## How Has This Been Tested?

No test is needed.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update