### PR TITLE
fix: idempotency per client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,11 @@ jobs:
             args: --features multitenant,analytics,geoblock,functional_tests
             cache: { sharedKey: "tests" }
             rustc: stable
+          - name: "Single-tenant functional tests"
+            cmd: test
+            args: --features functional_tests
+            cache: { sharedKey: "tests" }
+            rustc: stable
         include:
           - os: ubuntu-latest
             sccache-path: /home/runner/.cache/sccache
@@ -138,7 +143,7 @@ jobs:
         run: |
           sccache --stop-server || true
           sccache --start-server
-          
+
       - name: Install lld and llvm
         run: sudo apt-get install -y lld llvm
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +914,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,6 +1129,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
+name = "deadpool"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "retain_mut",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63dfa964fe2a66f3fde91fc70b267fe193d822c7e603e2a675a49a7f46ad3f49"
+
+[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1290,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "wc",
+ "wiremock",
 ]
 
 [[package]]
@@ -1512,6 +1562,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,6 +1598,12 @@ name = "futures-task"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -1758,6 +1829,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "base64 0.13.1",
+ "futures-lite",
+ "http",
+ "infer",
+ "pin-project-lite",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "url",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +1992,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.1",
 ]
+
+[[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "instant"
@@ -2496,6 +2594,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3050,6 +3154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "retain_mut"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3271,6 +3381,17 @@ checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
 dependencies = [
  "itoa",
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -4103,6 +4224,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -4143,6 +4265,12 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "want"
@@ -4396,6 +4524,28 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.5.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "079aee011e8a8e625d16df9e785de30a6b77f80a6126092d76a57375f96448da"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.21.4",
+ "deadpool",
+ "futures",
+ "futures-timer",
+ "http-types",
+ "hyper",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ ipnet = "2.5"
 cerberus = { git = "https://github.com/WalletConnect/cerberus.git", tag = "v0.5.0" }
 async-recursion = "1.0.4"
 tap = "1.0.1"
+wiremock = "0.5.21"
 
 [dev-dependencies]
 serial_test = "1.0"

--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -49,13 +49,13 @@ pub struct PushMessageBody {
 
 pub async fn handler(
     #[cfg(feature = "analytics")] SecureClientIp(client_ip): SecureClientIp,
-    Path((tenant_id, id)): Path<(String, String)>,
+    Path((tenant_id, client_id)): Path<(String, String)>,
     StateExtractor(state): StateExtractor<Arc<AppState>>,
     headers: HeaderMap,
     RequireValidSignature(Json(body)): RequireValidSignature<Json<PushMessageBody>>,
 ) -> Result<axum::response::Response, Error> {
     let res = handler_internal(
-        Path((tenant_id.clone(), id.clone())),
+        Path((tenant_id.clone(), client_id.clone())),
         StateExtractor(state.clone()),
         headers.clone(),
         RequireValidSignature(Json(body.clone())),

--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -116,7 +116,7 @@ pub async fn handler(
                 debug!(
                     %request_id,
                     %tenant_id,
-                    client_id = %id,
+                    client_id = %client_id,
                     ip = %client_ip,
                     "loaded geo data"
                 );
@@ -224,7 +224,7 @@ pub async fn handler_internal(
                 warn!(
                     %request_id,
                     %tenant_id,
-                    client_id = %id,
+                    client_id = %client_id,
                     "client tenant id has not been set, allowing request to continue"
                 );
             } else {

--- a/src/providers/noop.rs
+++ b/src/providers/noop.rs
@@ -1,6 +1,7 @@
 use {
     crate::{handlers::push_message::MessagePayload, providers::PushProvider},
     async_trait::async_trait,
+    reqwest::Url,
     std::collections::HashMap,
     tracing::span,
 };
@@ -31,6 +32,10 @@ impl PushProvider for NoopProvider {
 
         let notifications = self.notifications.get_mut(&token).unwrap();
         notifications.append(&mut vec![payload]);
+
+        if let Ok(url) = token.parse::<Url>() {
+            assert!(reqwest::get(url).await?.status().is_success());
+        }
 
         Ok(())
     }

--- a/src/stores/notification.rs
+++ b/src/stores/notification.rs
@@ -29,7 +29,7 @@ pub trait NotificationStore {
         client_id: &str,
         payload: &MessagePayload,
     ) -> stores::Result<Notification>;
-    async fn get_notification(&self, id: &str, tenant_id: &str) -> stores::Result<Notification>;
+    async fn get_notification(&self, id: &str, client_id: &str, tenant_id: &str) -> stores::Result<Notification>;
     async fn delete_notification(&self, id: &str, tenant_id: &str) -> stores::Result<()>;
 }
 
@@ -62,11 +62,12 @@ RETURNING *;",
         }
     }
 
-    async fn get_notification(&self, id: &str, tenant_id: &str) -> stores::Result<Notification> {
+    async fn get_notification(&self, id: &str, client_id: &str, tenant_id: &str) -> stores::Result<Notification> {
         let res = sqlx::query_as::<sqlx::postgres::Postgres, Notification>(
-            "SELECT * FROM public.notifications WHERE id = $1 and tenant_id = $2",
+            "SELECT * FROM public.notifications WHERE id = $1 AND client_id = $2 AND tenant_id = $3",
         )
         .bind(id)
+        .bind(client_id)
         .bind(tenant_id)
         .fetch_one(self)
         .await;

--- a/src/stores/notification.rs
+++ b/src/stores/notification.rs
@@ -29,7 +29,12 @@ pub trait NotificationStore {
         client_id: &str,
         payload: &MessagePayload,
     ) -> stores::Result<Notification>;
-    async fn get_notification(&self, id: &str, client_id: &str, tenant_id: &str) -> stores::Result<Notification>;
+    async fn get_notification(
+        &self,
+        id: &str,
+        client_id: &str,
+        tenant_id: &str,
+    ) -> stores::Result<Notification>;
     async fn delete_notification(&self, id: &str, tenant_id: &str) -> stores::Result<()>;
 }
 
@@ -62,9 +67,17 @@ RETURNING *;",
         }
     }
 
-    async fn get_notification(&self, id: &str, client_id: &str, tenant_id: &str) -> stores::Result<Notification> {
+    async fn get_notification(
+        &self,
+        id: &str,
+        client_id: &str,
+        tenant_id: &str,
+    ) -> stores::Result<Notification> {
         let res = sqlx::query_as::<sqlx::postgres::Postgres, Notification>(
-            "SELECT * FROM public.notifications WHERE id = $1 AND client_id = $2 AND tenant_id = $3",
+            "
+            SELECT *
+            FROM public.notifications
+            WHERE id = $1 AND client_id = $2 AND tenant_id = $3",
         )
         .bind(id)
         .bind(client_id)

--- a/tests/functional/singletenant/push.rs
+++ b/tests/functional/singletenant/push.rs
@@ -17,7 +17,7 @@ use {
     wiremock::{http::Method, matchers::method, Mock, MockServer, ResponseTemplate},
 };
 
-async fn create_client(ctx: &mut EchoServerContext) -> (ClientId, String, MockServer) {
+async fn create_client(ctx: &mut EchoServerContext) -> (ClientId, MockServer) {
     let mut rng = StdRng::from_entropy();
     let keypair = Keypair::generate(&mut rng);
 
@@ -65,13 +65,13 @@ async fn create_client(ctx: &mut EchoServerContext) -> (ClientId, String, MockSe
         "Response was not successful"
     );
 
-    (client_id, token, mock_server)
+    (client_id, mock_server)
 }
 
 #[test_context(EchoServerContext)]
 #[tokio::test]
 async fn test_push(ctx: &mut EchoServerContext) {
-    let (client_id, token, _mock_server) = create_client(ctx).await;
+    let (client_id, _mock_server) = create_client(ctx).await;
 
     // Push
     let push_message_id = Uuid::new_v4().to_string();
@@ -129,8 +129,8 @@ async fn test_push(ctx: &mut EchoServerContext) {
 #[test_context(EchoServerContext)]
 #[tokio::test]
 async fn test_push_multiple_clients(ctx: &mut EchoServerContext) {
-    let (client_id1, token1, _mock_server1) = create_client(ctx).await;
-    let (client_id2, token2, _mock_server2) = create_client(ctx).await;
+    let (client_id1, _mock_server1) = create_client(ctx).await;
+    let (client_id2, _mock_server2) = create_client(ctx).await;
 
     // Push
     let push_message_id = Uuid::new_v4().to_string();

--- a/tests/functional/singletenant/push.rs
+++ b/tests/functional/singletenant/push.rs
@@ -37,7 +37,7 @@ async fn create_client(ctx: &mut EchoServerContext) -> (ClientId, String, MockSe
         let mock_server = MockServer::start().await;
         Mock::given(method(Method::Get))
             .respond_with(ResponseTemplate::new(StatusCode::OK))
-            .expect(0..0)
+            .expect(1)
             .mount(&mock_server)
             .await;
         mock_server

--- a/tests/functional/singletenant/push.rs
+++ b/tests/functional/singletenant/push.rs
@@ -37,7 +37,7 @@ async fn create_client(ctx: &mut EchoServerContext) -> (ClientId, String, MockSe
         let mock_server = MockServer::start().await;
         Mock::given(method(Method::Get))
             .respond_with(ResponseTemplate::new(StatusCode::OK))
-            .expect(1..1)
+            .expect(0..0)
             .mount(&mock_server)
             .await;
         mock_server

--- a/tests/functional/singletenant/push.rs
+++ b/tests/functional/singletenant/push.rs
@@ -4,6 +4,7 @@ use {
         push_message::{MessagePayload, PushMessageBody},
         register_client::RegisterBody,
     },
+    hyper::StatusCode,
     relay_rpc::{
         auth::{
             ed25519_dalek::Keypair,
@@ -13,11 +14,10 @@ use {
     },
     test_context::test_context,
     uuid::Uuid,
+    wiremock::{http::Method, matchers::method, Mock, MockServer, ResponseTemplate},
 };
 
-#[test_context(EchoServerContext)]
-#[tokio::test]
-async fn test_push(ctx: &mut EchoServerContext) {
+async fn create_client(ctx: &mut EchoServerContext) -> (ClientId, String, MockServer) {
     let mut rng = StdRng::from_entropy();
     let keypair = Keypair::generate(&mut rng);
 
@@ -33,10 +33,21 @@ async fn test_push(ctx: &mut EchoServerContext) {
         .unwrap()
         .to_string();
 
+    let mock_server = {
+        let mock_server = MockServer::start().await;
+        Mock::given(method(Method::Get))
+            .respond_with(ResponseTemplate::new(StatusCode::OK))
+            .expect(1..1)
+            .mount(&mock_server)
+            .await;
+        mock_server
+    };
+    let token = mock_server.uri();
+
     let payload = RegisterBody {
         client_id: client_id.clone(),
         push_type: "noop".to_string(),
-        token: "test".to_string(),
+        token: token.clone(),
     };
 
     // Register client
@@ -53,6 +64,14 @@ async fn test_push(ctx: &mut EchoServerContext) {
         response.status().is_success(),
         "Response was not successful"
     );
+
+    (client_id, token, mock_server)
+}
+
+#[test_context(EchoServerContext)]
+#[tokio::test]
+async fn test_push(ctx: &mut EchoServerContext) {
+    let (client_id, token, _mock_server) = create_client(ctx).await;
 
     // Push
     let push_message_id = Uuid::new_v4().to_string();
@@ -103,6 +122,61 @@ async fn test_push(ctx: &mut EchoServerContext) {
     assert_eq!(
         response.status().as_u16(),
         already_pushed_status_code,
+        "Response was not successful"
+    );
+}
+
+#[test_context(EchoServerContext)]
+#[tokio::test]
+async fn test_push_multiple_clients(ctx: &mut EchoServerContext) {
+    let (client_id1, token1, _mock_server1) = create_client(ctx).await;
+    let (client_id2, token2, _mock_server2) = create_client(ctx).await;
+
+    // Push
+    let push_message_id = Uuid::new_v4().to_string();
+    let topic = Uuid::new_v4().to_string();
+    let blob = Uuid::new_v4().to_string();
+    let push_message_payload = MessagePayload {
+        topic: topic.into(),
+        blob: blob.to_string(),
+        flags: 0,
+    };
+    let payload = PushMessageBody {
+        id: push_message_id.clone(),
+        payload: push_message_payload,
+    };
+
+    // Push client 1
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!(
+            "http://{}/clients/{}",
+            ctx.server.public_addr,
+            client_id1.clone()
+        ))
+        .json(&payload)
+        .send()
+        .await
+        .expect("Call failed");
+    assert!(
+        response.status().is_success(),
+        "Response was not successful"
+    );
+
+    // Push client 2
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!(
+            "http://{}/clients/{}",
+            ctx.server.public_addr,
+            client_id2.clone()
+        ))
+        .json(&payload)
+        .send()
+        .await
+        .expect("Call failed");
+    assert!(
+        response.status().is_success(),
         "Response was not successful"
     );
 }

--- a/tests/functional/stores/client.rs
+++ b/tests/functional/stores/client.rs
@@ -96,7 +96,7 @@ async fn client_upsert_token(ctx: &mut StoreContext) {
         .unwrap();
     let get_notification_result = ctx
         .notifications
-        .get_notification(&notification_id, TENANT_ID)
+        .get_notification(&notification_id, &client_id, TENANT_ID)
         .await
         .unwrap();
     assert_eq!(get_notification_result.client_id, client_id);
@@ -159,7 +159,7 @@ async fn client_upsert_id(ctx: &mut StoreContext) {
         .unwrap();
     let get_notification_result = ctx
         .notifications
-        .get_notification(&notification_id, TENANT_ID)
+        .get_notification(&notification_id, &client_id, TENANT_ID)
         .await
         .unwrap();
     assert_eq!(get_notification_result.client_id, client_id);
@@ -226,7 +226,7 @@ async fn client_create_same_id_and_token(ctx: &mut StoreContext) {
         .unwrap();
     let get_notification_result = ctx
         .notifications
-        .get_notification(&notification_id, TENANT_ID)
+        .get_notification(&notification_id, &client_id, TENANT_ID)
         .await
         .unwrap();
     assert_eq!(get_notification_result.client_id, client_id);


### PR DESCRIPTION
# Description

If multiple clients are subscribed to the same topic and are registered to receive push notifications, this won't work because the idempotency logic is designed to prevent the same message ID from being notified multiple times.

This behavior was actually flakey due to the idempotency logic itself not being robust against race conditions, but this is a separate issue. 

Context: https://walletconnect.slack.com/archives/C044SKFKELR/p1699446818332569?thread_ts=1699442986.858579&cid=C044SKFKELR

Resolves #273

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update