### PR TITLE
chore: fix all warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,19 @@ jobs:
         os:
           - ubuntu-latest
         cargo:
-          - name: "Clippy"
+          - name: "Clippy default features"
             cmd: clippy
-            args: --all-features --release -- -D clippy::all
+            args: --tests -- -D warnings
+            cache: {}
+            rustc: stable
+          - name: "Clippy multitenant feature, no analytics feature"
+            cmd: clippy
+            args: --features=multitenant --tests -- -D warnings
+            cache: {}
+            rustc: stable
+          - name: "Clippy all features"
+            cmd: clippy
+            args: --all-features --tests -- -D warnings
             cache: {}
             rustc: stable
           - name: "Formatting"

--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -240,6 +240,7 @@ pub async fn handler_internal(
                     return Err((Error::MissmatchedTenantId, analytics));
                 }
 
+                #[cfg(not(feature = "analytics"))]
                 return Err((Error::MissmatchedTenantId, None));
             }
         }
@@ -453,5 +454,6 @@ pub async fn handler_internal(
         return Ok(((StatusCode::ACCEPTED).into_response(), analytics));
     }
 
+    #[cfg(not(feature = "analytics"))]
     Ok(((StatusCode::ACCEPTED).into_response(), None))
 }

--- a/src/handlers/update_apns.rs
+++ b/src/handlers/update_apns.rs
@@ -14,7 +14,7 @@ use {
     },
     base64::Engine,
     serde::{Deserialize, Serialize},
-    std::{io::BufReader, sync::Arc},
+    std::sync::Arc,
     tracing::{error, warn},
 };
 

--- a/tests/context/mod.rs
+++ b/tests/context/mod.rs
@@ -94,6 +94,10 @@ impl AsyncTestContext for EchoServerContext {
         let server = EchoServer::start(ConfigContext::setup().config).await;
         Self { server, config }
     }
+
+    async fn teardown(mut self) {
+        self.server.shutdown().await;
+    }
 }
 
 #[async_trait]

--- a/tests/context/server.rs
+++ b/tests/context/server.rs
@@ -47,7 +47,7 @@ async fn start_server(
     bool,
 ) {
     let rt = Handle::current();
-    let port = config.port.clone();
+    let port = config.port;
     let public_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port);
 
     let (signal, shutdown) = broadcast::channel(1);

--- a/tests/functional/multitenant/apns.rs
+++ b/tests/functional/multitenant/apns.rs
@@ -3,7 +3,7 @@ use {
     echo_server::handlers::create_tenant::TenantRegisterBody,
     jsonwebtoken::{encode, EncodingKey, Header},
     random_string::generate,
-    std::time::SystemTime,
+    std::{env, time::SystemTime},
     test_context::test_context,
     uuid::Uuid,
 };
@@ -47,11 +47,14 @@ async fn tenant_update_apns_valid_token(ctx: &mut EchoServerContext) {
     let form = reqwest::multipart::Form::new()
         .text("apns_type", "token")
         .text("apns_topic", "app.test")
-        .text("apns_key_id", env!("ECHO_TEST_APNS_P8_KEY_ID"))
-        .text("apns_team_id", env!("ECHO_TEST_APNS_P8_TEAM_ID"))
+        .text("apns_key_id", env::var("ECHO_TEST_APNS_P8_KEY_ID").unwrap())
+        .text(
+            "apns_team_id",
+            env::var("ECHO_TEST_APNS_P8_TEAM_ID").unwrap(),
+        )
         .part(
             "apns_pkcs8_pem",
-            reqwest::multipart::Part::text(env!("ECHO_TEST_APNS_P8_PEM"))
+            reqwest::multipart::Part::text(env::var("ECHO_TEST_APNS_P8_PEM").unwrap())
                 .file_name("apns.p8")
                 .mime_str("text/plain")
                 .expect("Error on passing multipart stream to the form request"),

--- a/tests/functional/multitenant/fcm.rs
+++ b/tests/functional/multitenant/fcm.rs
@@ -3,7 +3,7 @@ use {
     echo_server::handlers::create_tenant::TenantRegisterBody,
     jsonwebtoken::{encode, EncodingKey, Header},
     random_string::generate,
-    std::time::SystemTime,
+    std::{env, time::SystemTime},
     test_context::test_context,
 };
 
@@ -44,7 +44,7 @@ async fn tenant_update_fcm_valid(ctx: &mut EchoServerContext) {
     assert_eq!(register_response.status(), reqwest::StatusCode::OK);
 
     // Send valid API Key
-    let api_key = env!("ECHO_TEST_FCM_KEY");
+    let api_key = env::var("ECHO_TEST_FCM_KEY").unwrap();
     let form = reqwest::multipart::Form::new().text("api_key", api_key);
 
     let response_fcm_update = client

--- a/tests/unit/messages.rs
+++ b/tests/unit/messages.rs
@@ -37,7 +37,7 @@ pub fn check_payload_not_encrypted() {
         blob: EXAMPLE_CLEARTEXT_ENCODED_BLOB.to_string(),
     };
 
-    assert_eq!(payload.is_encrypted(), false)
+    assert!(!payload.is_encrypted());
 }
 
 #[test]

--- a/tests/unit/middleware/validate_signature.rs
+++ b/tests/unit/middleware/validate_signature.rs
@@ -47,7 +47,7 @@ pub async fn invalid_signature_not_hex() {
     // Should error
     assert!(res.is_err());
 
-    let error = res.err().expect("Couldn't unwrap error");
+    let error = res.expect_err("Couldn't unwrap error");
     assert!(error.is_hex());
 }
 
@@ -67,7 +67,7 @@ pub async fn invalid_signature_hex() {
     // Should error
     assert!(res.is_err());
 
-    let error = res.err().expect("Couldn't unwrap error");
+    let error = res.expect_err("Couldn't unwrap error");
     // Note: should be a from slice error as the signature
     assert!(error.is_ed_25519());
 }


### PR DESCRIPTION
# Description

- Change clippy to deny all warnings. Denying `clippy::all` doesn't deny normal compiler warnings, and `clippy::all` is [already warning by default](https://github.com/rust-lang/rust-clippy), so denying `warnings` includes everything.
- Also add 2 more clippy invocations with different sets of feature flags to detect all the code paths that were previously not tested by clippy.
- Fix all the warnings.
- Change `env!()` to `std::env::var()` to allow running clippy without these env vars set. Not sure why these were being compiled into the binary.

## How Has This Been Tested?

CI tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update