### PR TITLE
feat(decrypted_notify): adding `always_raw` for the client registration

### DIFF
--- a/migrations/1699982551_add_always_raw_to_clients.sql
+++ b/migrations/1699982551_add_always_raw_to_clients.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.clients
+    ADD COLUMN always_raw BOOLEAN DEFAULT FALSE;

--- a/src/handlers/register_client.rs
+++ b/src/handlers/register_client.rs
@@ -28,6 +28,7 @@ pub struct RegisterBody {
     #[serde(rename = "type")]
     pub push_type: String,
     pub token: String,
+    pub always_raw: Option<bool>,
 }
 
 pub async fn handler(
@@ -93,6 +94,7 @@ pub async fn handler(
             tenant_id: tenant_id.clone(),
             push_type,
             token: body.token,
+            always_raw: body.always_raw.unwrap_or(false),
         })
         .await?;
 

--- a/tests/functional/singletenant/push.rs
+++ b/tests/functional/singletenant/push.rs
@@ -48,6 +48,7 @@ async fn create_client(ctx: &mut EchoServerContext) -> (ClientId, MockServer) {
         client_id: client_id.clone(),
         push_type: "noop".to_string(),
         token: token.clone(),
+        always_raw: Some(false),
     };
 
     // Register client

--- a/tests/functional/singletenant/registration.rs
+++ b/tests/functional/singletenant/registration.rs
@@ -23,6 +23,7 @@ async fn test_registration(ctx: &mut EchoServerContext) {
         client_id: client_id.clone(),
         push_type: "noop".to_string(),
         token: "test".to_string(),
+        always_raw: Some(false),
     };
 
     let jwt = relay_rpc::auth::AuthToken::new(client_id.value().clone())
@@ -54,6 +55,7 @@ async fn test_registration(ctx: &mut EchoServerContext) {
         client_id,
         push_type: "noop".to_string(),
         token: "new_token".to_string(),
+        always_raw: Some(false),
     };
     let response = client
         .post(format!("http://{}/clients", ctx.server.public_addr))
@@ -91,6 +93,7 @@ async fn test_deregistration(ctx: &mut EchoServerContext) {
         client_id: client_id.clone(),
         push_type: "noop".to_string(),
         token: "test".to_string(),
+        always_raw: Some(false),
     };
 
     let client = reqwest::Client::new();

--- a/tests/functional/stores/client.rs
+++ b/tests/functional/stores/client.rs
@@ -17,6 +17,7 @@ async fn client_creation(ctx: &mut StoreContext) {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Noop,
             token,
+            always_raw: false,
         })
         .await
         .unwrap();
@@ -34,6 +35,7 @@ async fn client_creation_fcm(ctx: &mut StoreContext) {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Fcm,
             token,
+            always_raw: false,
         })
         .await
         .unwrap();
@@ -51,6 +53,7 @@ async fn client_creation_apns(ctx: &mut StoreContext) {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Apns,
             token,
+            always_raw: false,
         })
         .await
         .unwrap();
@@ -70,6 +73,7 @@ async fn client_upsert_token(ctx: &mut StoreContext) {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Fcm,
             token: token.clone(),
+            always_raw: false,
         })
         .await
         .unwrap();
@@ -108,11 +112,13 @@ async fn client_upsert_token(ctx: &mut StoreContext) {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Apns,
             token: updated_token.clone(),
+            always_raw: true,
         })
         .await
         .unwrap();
     let updated_token_result = ctx.clients.get_client(TENANT_ID, &client_id).await.unwrap();
     assert_eq!(updated_token_result.token, updated_token);
+    assert!(updated_token_result.always_raw);
 
     // Cleaning up records
     ctx.clients
@@ -133,6 +139,7 @@ async fn client_upsert_id(ctx: &mut StoreContext) {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Fcm,
             token: token.clone(),
+            always_raw: false,
         })
         .await
         .unwrap();
@@ -171,6 +178,7 @@ async fn client_upsert_id(ctx: &mut StoreContext) {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Fcm,
             token: token.clone(),
+            always_raw: false,
         })
         .await
         .unwrap();
@@ -200,6 +208,7 @@ async fn client_create_same_id_and_token(ctx: &mut StoreContext) {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Fcm,
             token: token.clone(),
+            always_raw: false,
         })
         .await
         .unwrap();
@@ -238,6 +247,7 @@ async fn client_create_same_id_and_token(ctx: &mut StoreContext) {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Noop,
             token: token.clone(),
+            always_raw: false,
         })
         .await
         .unwrap();
@@ -263,6 +273,7 @@ async fn client_deletion(ctx: &mut StoreContext) {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Noop,
             token,
+            always_raw: false,
         })
         .await
         .unwrap();
@@ -280,6 +291,7 @@ async fn client_fetch(ctx: &mut StoreContext) {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Noop,
             token: token.clone(),
+            always_raw: false,
         })
         .await
         .unwrap();

--- a/tests/functional/stores/notification.rs
+++ b/tests/functional/stores/notification.rs
@@ -21,6 +21,7 @@ pub async fn create_client(client_store: &ClientStoreArc) -> String {
             tenant_id: TENANT_ID.to_string(),
             push_type: ProviderKind::Noop,
             token,
+            always_raw: false,
         })
         .await
         .expect("failed to create client for notification test");


### PR DESCRIPTION
# Description

This PR adds `always_raw` field to the clients database table and to the client register endpoint as an optional field with the `false` as default to follow the [specs for the decrypted notifications](https://github.com/WalletConnect/walletconnect-specs/pull/147/files#diff-25490e5dda4bcd46802fca4131439d45ab85cf408683b76c7604735dfe656edcR76).

Related to #278 

## How Has This Been Tested?

Updated functional tests.

## Review stack 🏗️
1 - Adding always_raw for the client registration #279 <-
2 - Update message payload and pass raw message #281

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update