### PR TITLE
fix: use new fields exclusively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3098,7 +3098,7 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 [[package]]
 name = "relay_rpc"
 version = "0.1.0"
-source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=ced99e7#ced99e7431176f51650d72b1662298757c7f2dc7"
+source = "git+https://github.com/WalletConnect/WalletConnectRust.git?rev=4ee9007#4ee90076b76ad575fc171a08c9538ab63d951b64"
 dependencies = [
  "bs58",
  "chrono",
@@ -3112,6 +3112,7 @@ dependencies = [
  "serde",
  "serde-aux",
  "serde_json",
+ "sha2 0.10.8",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ fcm = "0.9"
 ed25519-dalek = "2.0.0-rc.2"
 
 # JWT Authentication
-relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "ced99e7"}
+relay_rpc = { git = "https://github.com/WalletConnect/WalletConnectRust.git", rev = "4ee9007"}
 jsonwebtoken = "8.1"
 data-encoding = "2.3"
 

--- a/src/analytics/message_info.rs
+++ b/src/analytics/message_info.rs
@@ -11,6 +11,7 @@ pub struct MessageInfo {
     pub client_id: Arc<str>,
     pub topic: Arc<str>,
     pub push_provider: Arc<str>,
+    pub always_encrypted: bool,
     pub encrypted: bool,
     pub flags: u32,
     pub status: u16,

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -20,7 +20,7 @@ impl DecryptedPayloadBlob {
         Ok(serde_json::from_str(&blob_string)?)
     }
 
-    pub fn from_base64_encoded(blob_string: String) -> Result<DecryptedPayloadBlob> {
+    pub fn from_base64_encoded(blob_string: &str) -> Result<DecryptedPayloadBlob> {
         let blob_decoded = base64::engine::general_purpose::STANDARD.decode(blob_string)?;
         Ok(serde_json::from_slice(&blob_decoded)?)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -140,7 +140,7 @@ pub enum Error {
     InternalServerError,
 
     #[error(transparent)]
-    JwtError(#[from] relay_rpc::auth::JwtVerificationError),
+    JwtError(#[from] relay_rpc::jwt::JwtError),
 
     #[error("the provided authentication does not authenticate the request")]
     InvalidAuthentication,
@@ -180,9 +180,6 @@ pub enum Error {
 
     #[error("tenant suspended due to invalid configuration")]
     TenantSuspended,
-
-    #[error("Bad payload provided: {0}")]
-    BadPayload(String),
 }
 
 impl IntoResponse for Error {

--- a/src/providers/noop.rs
+++ b/src/providers/noop.rs
@@ -1,5 +1,6 @@
 use {
-    crate::{handlers::push_message::PushMessageBody, providers::PushProvider},
+    super::PushMessage,
+    crate::providers::PushProvider,
     async_trait::async_trait,
     reqwest::Url,
     std::collections::HashMap,
@@ -8,8 +9,7 @@ use {
 
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct NoopProvider {
-    // token -> [MessagePayload{..}, MessagePayload{..}, MessagePayload{..}]
-    notifications: HashMap<String, Vec<PushMessageBody>>,
+    notifications: HashMap<String, Vec<PushMessage>>,
 }
 
 impl NoopProvider {
@@ -24,8 +24,7 @@ impl PushProvider for NoopProvider {
     async fn send_notification(
         &mut self,
         token: String,
-        body: PushMessageBody,
-        _always_raw: bool,
+        body: PushMessage,
     ) -> crate::error::Result<()> {
         self.bootstrap(token.clone());
 

--- a/src/stores/notification.rs
+++ b/src/stores/notification.rs
@@ -1,10 +1,11 @@
 use {
     crate::{
-        handlers::push_message::MessagePayload,
+        handlers::push_message::PushMessageBody,
         stores::{self, StoreError::NotFound},
     },
     async_trait::async_trait,
     chrono::{DateTime, Utc},
+    serde_json::Value,
     sqlx::{types::Json, Executor},
 };
 
@@ -13,8 +14,8 @@ pub struct Notification {
     pub id: String,
     pub client_id: String,
 
-    pub last_payload: Json<MessagePayload>,
-    pub previous_payloads: Vec<Json<MessagePayload>>,
+    pub last_payload: Json<Value>,
+    pub previous_payloads: Vec<Json<Value>>,
 
     pub last_received_at: DateTime<Utc>,
     pub created_at: DateTime<Utc>,
@@ -27,7 +28,7 @@ pub trait NotificationStore {
         id: &str,
         tenant_id: &str,
         client_id: &str,
-        payload: &MessagePayload,
+        payload: &PushMessageBody,
     ) -> stores::Result<Notification>;
     async fn get_notification(
         &self,
@@ -45,7 +46,7 @@ impl NotificationStore for sqlx::PgPool {
         id: &str,
         tenant_id: &str,
         client_id: &str,
-        payload: &MessagePayload,
+        payload: &PushMessageBody,
     ) -> stores::Result<Notification> {
         let res = sqlx::query_as::<sqlx::postgres::Postgres, Notification>(
             "

--- a/tests/functional/singletenant/push.rs
+++ b/tests/functional/singletenant/push.rs
@@ -195,7 +195,7 @@ async fn test_push_always_raw(ctx: &mut EchoServerContext) {
     // Create client with always_raw = true
     let (client_id, _mock_server) = create_client(ctx, true).await;
 
-    let push_message_id = Uuid::new_v4().to_string();
+    let push_message_id = Uuid::new_v4().to_string().into();
     let topic: Arc<str> = Uuid::new_v4().to_string().into();
     let blob: Arc<str> = Uuid::new_v4().to_string().into();
     let push_message_payload = MessagePayload {
@@ -209,7 +209,7 @@ async fn test_push_always_raw(ctx: &mut EchoServerContext) {
     let wrong_payload = PushMessageBody {
         new: None,
         old: Some(OldPushMessage {
-            id: push_message_id.clone().into(),
+            id: push_message_id,
             payload: push_message_payload,
         }),
     };

--- a/tests/functional/singletenant/registration.rs
+++ b/tests/functional/singletenant/registration.rs
@@ -26,7 +26,7 @@ async fn test_registration(ctx: &mut EchoServerContext) {
         always_raw: Some(false),
     };
 
-    let jwt = relay_rpc::auth::AuthToken::new(client_id.value().clone())
+    let jwt = relay_rpc::auth::AuthToken::new(client_id.value().to_string())
         .aud(format!(
             "http://127.0.0.1:{}",
             ctx.server.public_addr.port()
@@ -80,7 +80,7 @@ async fn test_deregistration(ctx: &mut EchoServerContext) {
     let random_client_id = DecodedClientId(*keypair.public_key().as_bytes());
     let client_id = ClientId::from(random_client_id);
 
-    let jwt = relay_rpc::auth::AuthToken::new(client_id.value().clone())
+    let jwt = relay_rpc::auth::AuthToken::new(client_id.value().to_string())
         .aud(format!(
             "http://127.0.0.1:{}",
             ctx.server.public_addr.port()

--- a/tests/functional/stores/client.rs
+++ b/tests/functional/stores/client.rs
@@ -3,7 +3,11 @@ use {
         context::StoreContext,
         functional::stores::{gen_id, TENANT_ID},
     },
-    echo_server::{providers::ProviderKind, stores::client::Client},
+    echo_server::{
+        handlers::push_message::PushMessageBody,
+        providers::ProviderKind,
+        stores::client::Client,
+    },
     test_context::test_context,
 };
 
@@ -83,19 +87,12 @@ async fn client_upsert_token(ctx: &mut StoreContext) {
     // Insert notification for the client to test the clients->notifications
     // constraint works properly
     let notification_id = format!("id-{}", gen_id());
-    let notification_payload = format!("payload-{}", gen_id());
 
     ctx.notifications
-        .create_or_update_notification(
-            &notification_id,
-            TENANT_ID,
-            &client_id,
-            &echo_server::handlers::push_message::MessagePayload {
-                topic: String::new(),
-                flags: 0,
-                blob: notification_payload,
-            },
-        )
+        .create_or_update_notification(&notification_id, TENANT_ID, &client_id, &PushMessageBody {
+            new: None,
+            old: None,
+        })
         .await
         .unwrap();
     let get_notification_result = ctx
@@ -149,19 +146,12 @@ async fn client_upsert_id(ctx: &mut StoreContext) {
     // Insert notification for the client to test the clients->notifications
     // constraint works properly
     let notification_id = format!("id-{}", gen_id());
-    let notification_payload = format!("payload-{}", gen_id());
 
     ctx.notifications
-        .create_or_update_notification(
-            &notification_id,
-            TENANT_ID,
-            &client_id,
-            &echo_server::handlers::push_message::MessagePayload {
-                topic: String::new(),
-                flags: 0,
-                blob: notification_payload,
-            },
-        )
+        .create_or_update_notification(&notification_id, TENANT_ID, &client_id, &PushMessageBody {
+            new: None,
+            old: None,
+        })
         .await
         .unwrap();
     let get_notification_result = ctx
@@ -218,19 +208,12 @@ async fn client_create_same_id_and_token(ctx: &mut StoreContext) {
     // Insert notification for the client to test the clients->notifications
     // constraint works properly
     let notification_id = format!("id-{}", gen_id());
-    let notification_payload = format!("payload-{}", gen_id());
 
     ctx.notifications
-        .create_or_update_notification(
-            &notification_id,
-            TENANT_ID,
-            &client_id,
-            &echo_server::handlers::push_message::MessagePayload {
-                topic: String::new(),
-                flags: 0,
-                blob: notification_payload,
-            },
-        )
+        .create_or_update_notification(&notification_id, TENANT_ID, &client_id, &PushMessageBody {
+            new: None,
+            old: None,
+        })
         .await
         .unwrap();
     let get_notification_result = ctx

--- a/tests/functional/stores/notification.rs
+++ b/tests/functional/stores/notification.rs
@@ -4,7 +4,7 @@ use {
         functional::stores::{gen_id, TENANT_ID},
     },
     echo_server::{
-        handlers::push_message::MessagePayload,
+        handlers::push_message::PushMessageBody,
         providers::ProviderKind,
         state::ClientStoreArc,
         stores::client::Client,
@@ -36,10 +36,9 @@ async fn notification(ctx: &mut StoreContext) {
 
     let res = ctx
         .notifications
-        .create_or_update_notification(&gen_id(), TENANT_ID, &client_id, &MessagePayload {
-            topic: String::new(),
-            flags: 0,
-            blob: "example-payload".to_string(),
+        .create_or_update_notification(&gen_id(), TENANT_ID, &client_id, &PushMessageBody {
+            new: None,
+            old: None,
         })
         .await;
 
@@ -50,10 +49,9 @@ async fn notification(ctx: &mut StoreContext) {
 #[tokio::test]
 async fn notification_multiple_clients_same_payload(ctx: &mut StoreContext) {
     let message_id = gen_id();
-    let payload = MessagePayload {
-        topic: String::new(),
-        flags: 0,
-        blob: "example-payload".to_string(),
+    let payload = PushMessageBody {
+        new: None,
+        old: None,
     };
 
     let client_id1 = create_client(&ctx.clients).await;

--- a/tests/unit/messages.rs
+++ b/tests/unit/messages.rs
@@ -1,6 +1,6 @@
 use echo_server::{
     blob::{DecryptedPayloadBlob, ENCRYPTED_FLAG},
-    handlers::push_message::MessagePayload,
+    providers::MessagePayload,
 };
 
 const EXAMPLE_TOPIC: &str = "example-topic";
@@ -21,9 +21,9 @@ const EXAMPLE_ENCRYPTED_BLOB: &str = "encrypted-blob";
 #[test]
 pub fn check_payload_encrypted() {
     let payload = MessagePayload {
-        topic: EXAMPLE_TOPIC.to_string(),
+        topic: EXAMPLE_TOPIC.to_string().into(),
         flags: ENCRYPTED_FLAG,
-        blob: EXAMPLE_ENCRYPTED_BLOB.to_string(),
+        blob: EXAMPLE_ENCRYPTED_BLOB.to_string().into(),
     };
 
     assert!(payload.is_encrypted())
@@ -32,9 +32,9 @@ pub fn check_payload_encrypted() {
 #[test]
 pub fn check_payload_not_encrypted() {
     let payload = MessagePayload {
-        topic: EXAMPLE_TOPIC.to_string(),
+        topic: EXAMPLE_TOPIC.to_string().into(),
         flags: 0,
-        blob: EXAMPLE_CLEARTEXT_ENCODED_BLOB.to_string(),
+        blob: EXAMPLE_CLEARTEXT_ENCODED_BLOB.to_string().into(),
     };
 
     assert!(!payload.is_encrypted());
@@ -43,12 +43,12 @@ pub fn check_payload_not_encrypted() {
 #[test]
 pub fn parse_blob_from_payload() {
     let payload = MessagePayload {
-        topic: EXAMPLE_TOPIC.to_string(),
+        topic: EXAMPLE_TOPIC.to_string().into(),
         flags: 0,
-        blob: EXAMPLE_CLEARTEXT_ENCODED_BLOB.to_string(),
+        blob: EXAMPLE_CLEARTEXT_ENCODED_BLOB.to_string().into(),
     };
 
-    let blob = DecryptedPayloadBlob::from_base64_encoded(payload.blob)
+    let blob = DecryptedPayloadBlob::from_base64_encoded(&payload.blob)
         .expect("Failed to parse payload's blob");
 
     assert_eq!(blob, DecryptedPayloadBlob {
@@ -61,9 +61,8 @@ pub fn parse_blob_from_payload() {
 
 #[test]
 pub fn parse_encoded_blob() {
-    let blob =
-        DecryptedPayloadBlob::from_base64_encoded(EXAMPLE_CLEARTEXT_ENCODED_BLOB.to_string())
-            .expect("Failed to parse encoded blob");
+    let blob = DecryptedPayloadBlob::from_base64_encoded(EXAMPLE_CLEARTEXT_ENCODED_BLOB)
+        .expect("Failed to parse encoded blob");
 
     assert_eq!(blob, DecryptedPayloadBlob {
         title: EXAMPLE_CLEARTEXT_BLOB_TITLE.to_string(),


### PR DESCRIPTION
# Description

Improves on https://github.com/WalletConnect/echo-server/pull/281

- Adds missing tag to custom data
- When always_raw is enabled, use the new fields exclusively for idempotency
  - Required updating to latest version of WalletConnectRust library, which had minor impacts on JWT parsing code
- Makes new and old fields both optional, with the usage determined by the client's `always_raw` preference.

## How Has This Been Tested?

Automated tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update