### PR TITLE
fix(o11y): registered client metric is wrong

### DIFF
--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -417,13 +417,13 @@ resource "grafana_dashboard" "at_a_glance" {
               "uid" : grafana_data_source.prometheus.uid
             },
             "exemplar" : true,
-            "expr" : "sum(registered_clients{})",
+            "expr" : "sum(increase(registered_clients{}[1h]))",
             "interval" : "",
             "legendFormat" : "",
             "refId" : "Clients"
           }
         ],
-        "title" : "Registered Clients",
+        "title" : "Registered Clients past 1h",
         "type" : "timeseries"
       },
       {


### PR DESCRIPTION
# Description

Noticed that the graph is broken. This fixes it to show a correct number of registered clients.

## How Has This Been Tested?

Tested in Grafana.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update