### PR TITLE
fix: adding the pg_lock for the token

### DIFF
--- a/src/stores/client.rs
+++ b/src/stores/client.rs
@@ -35,9 +35,15 @@ impl ClientStore for sqlx::PgPool {
 
         let mut transaction = self.begin().await?;
 
-        // Statement for locking to prevent an issue #230
+        // Statement for locking based on the client id to prevent an issue #230
         sqlx::query("SELECT pg_advisory_xact_lock(abs(hashtext($1::text)))")
             .bind(id)
+            .execute(&mut transaction)
+            .await?;
+
+        // Statement for locking based on the token to prevent an issue #292
+        sqlx::query("SELECT pg_advisory_xact_lock(abs(hashtext($1::text)))")
+            .bind(client.token.clone())
             .execute(&mut transaction)
             .await?;
 


### PR DESCRIPTION
# Description

This PR adds an additional `pg_advisory_xact_lock` based on the device token to prevent data race when concurrent client creations occur with the same token id and different client IDs, because at the moment only the client ID is used for the lock. In such cases, we have an `unique constraint violation` error for the device token because we have [a parallel insert](https://github.com/WalletConnect/echo-server/blob/3fca011fa9b2e398198b5b5621260d0a82385f54/src/stores/client.rs#L51).

The `pg_advisory_xact_lock`s are released at the [end of the transaction](https://github.com/WalletConnect/echo-server/blob/3fca011fa9b2e398198b5b5621260d0a82385f54/src/stores/client.rs#L70).

Resolves #292

## How Has This Been Tested?

Current functional [database tests](https://github.com/WalletConnect/echo-server/actions/runs/7194773344/job/19596015598?pr=293#step:11:803).

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update