### PR TITLE
fix(alarms): increasing 5xx alarm threshold from 5 to 15

### DIFF
--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -547,7 +547,7 @@ resource "grafana_dashboard" "at_a_glance" {
             {
               "evaluator" : {
                 "params" : [
-                  5
+                  15
                 ],
                 "type" : "gt"
               },
@@ -570,7 +570,7 @@ resource "grafana_dashboard" "at_a_glance" {
             {
               "evaluator" : {
                 "params" : [
-                  5
+                  15
                 ],
                 "type" : "gt"
               },


### PR DESCRIPTION
# Description

This PR increases the 5xx alarm threshold from 5 to 15 to eliminate alerts on FCM connection errors up to 15.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update