### PR TITLE
fix: increasing Postgres connection pool size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,8 @@ pub mod state;
 pub mod stores;
 pub mod supabase;
 
+const PG_CONNECTION_POOL_SIZE: u32 = 30;
+
 pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Config) -> error::Result<()> {
     // Check config is valid and then throw the error if its not
     config.is_valid()?;
@@ -76,7 +78,7 @@ pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Config) -> 
         .clone();
 
     let store = PgPoolOptions::new()
-        .max_connections(5)
+        .max_connections(PG_CONNECTION_POOL_SIZE)
         .connect_with(pg_options)
         .await?;
 
@@ -95,7 +97,7 @@ pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Config) -> 
             .clone();
 
         let tenant_database = PgPoolOptions::new()
-            .max_connections(5)
+            .max_connections(PG_CONNECTION_POOL_SIZE)
             .connect_with(tenant_pg_options)
             .await?;
 

--- a/tests/context/stores.rs
+++ b/tests/context/stores.rs
@@ -7,6 +7,8 @@ use {
     tracing::log::LevelFilter,
 };
 
+const PG_CONNECTION_POOL_SIZE: u32 = 30;
+
 pub async fn open_pg_connections(
     database_uri: &str,
     tenant_database_uri: &str,
@@ -18,7 +20,7 @@ pub async fn open_pg_connections(
         .clone();
 
     let pool = PgPoolOptions::new()
-        .max_connections(5)
+        .max_connections(PG_CONNECTION_POOL_SIZE)
         .connect_with(pg_options)
         .await
         .expect("failed to connect to postgres");
@@ -35,7 +37,7 @@ pub async fn open_pg_connections(
         .clone();
 
     let tenant_pool = PgPoolOptions::new()
-        .max_connections(5)
+        .max_connections(PG_CONNECTION_POOL_SIZE)
         .connect_with(tenant_pg_options)
         .await
         .expect("failed to connect to postgres");


### PR DESCRIPTION
# Description

This PR increases the Postgres connection pool size from `5` to `30` to handle request spikes properly.
During the request spikes there are `Store(Database(PoolTimedOut)` errors, that should be fixed by increasing the pool size. The RDS state at this moment remains stable (ACU <= 30%), so it should be handled without scaling.


## How Has This Been Tested?

Unit testing.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update