### PR TITLE
fix: increasing PgPool connections to `100`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub mod state;
 pub mod stores;
 pub mod supabase;
 
-const PG_CONNECTION_POOL_SIZE: u32 = 30;
+const PG_CONNECTION_POOL_SIZE: u32 = 100;
 
 pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Config) -> error::Result<()> {
     // Check config is valid and then throw the error if its not


### PR DESCRIPTION
# Description

This PR increases PgPool connections from `30` to `100`, leaving the `30` for tests.

## How Has This Been Tested?

Current unit tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update