### PR TITLE
fix: APNs certificate expired error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -169,11 +169,14 @@ pub enum Error {
     #[error("tenant id and client's registered tenant didn't match")]
     MissmatchedTenantId,
 
-    #[error("invalid fcm api key")]
+    #[error("Invalid FCM API key")]
     BadFcmApiKey,
 
-    #[error("invalid apns creds")]
+    #[error("Invalid APNs creds")]
     BadApnsCredentials,
+
+    #[error("Expired APNs certificate")]
+    ApnsCertificateExpired,
 
     #[error("client deleted due to invalid device token")]
     ClientDeleted,
@@ -568,11 +571,11 @@ impl IntoResponse for Error {
         }.into_response();
 
         if response.status().is_client_error() {
-            warn!("HTTP Client Error: {self:?}");
+            warn!("HTTP client error: {self:?}");
         }
 
         if response.status().is_server_error() {
-            error!("HTTP Server Error: {self:?}");
+            error!("HTTP server error: {self:?}");
         }
 
         response

--- a/src/providers/apns.rs
+++ b/src/providers/apns.rs
@@ -4,7 +4,7 @@ use {
     a2::{ErrorReason, NotificationBuilder, NotificationOptions},
     async_trait::async_trait,
     std::io::Read,
-    tracing::{debug, instrument, warn},
+    tracing::{debug, info, instrument, warn},
 };
 
 #[derive(Debug, Clone)]
@@ -145,6 +145,21 @@ impl PushProvider for ApnsProvider {
                         reason => Err(Error::ApnsResponse(reason)),
                     },
                 },
+                a2::Error::ConnectionError(ref hyper_error) => {
+                    let dbg = format!("{hyper_error:?}");
+                    // e.g. Apns(ConnectionError(hyper::Error(Io, Custom { kind: InvalidData, error: "received fatal alert: CertificateExpired" })))
+                    if dbg.contains("received fatal alert: CertificateExpired") {
+                        // Checking if debug fmt contains something is strange.
+                        // Logging stuff here temporarily so we can determine better
+                        // ways to detect this error (e.g. display). Ideally we can extract
+                        // the error field directly and check if exactly equal to the above
+                        // rather than using contains()
+                        info!("APNs certificate expired: debug:{dbg}, display: {hyper_error}");
+                        Err(Error::ApnsCertificateExpired)
+                    } else {
+                        Err(Error::Apns(e))
+                    }
+                }
                 e => Err(Error::Apns(e)),
             },
         }


### PR DESCRIPTION
# Description

[Slack conversation](https://walletconnect.slack.com/archives/C058RS0MH38/p1711387212819129)

Captures the client-side certificate expiration error and suspends the tenant when this happens. Also updates the capitalization on the server/client error logging to be consistent with other services.

Resolves #308 

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update