### PR TITLE
feat: refactored cloud auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,10 +20,6 @@ TENANT_DATABASE_URL=
 DEFAULT_TENANT_ID= # This has a default value and dosen't hold much impact to the running of echo-server
 JWT_SECRET=
 
-# Cloud App
-CLOUD_API_URL=
-CLOUD_API_KEY=
-
 # CORS
 CORS_ALLOWED_ORIGINS=*
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -83,7 +83,6 @@ jobs:
         env:
           GRAFANA_AUTH: ${{ steps.grafana-get-key.outputs.key }}
           TF_VAR_grafana_endpoint: ${{ steps.grafana-get-details.outputs.endpoint }}
-          TF_VAR_cloud_api_key: ${{ secrets.CLOUD_API_KEY }}
           TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
           TF_VAR_image_version: ${{ inputs.image_tag }}
           TF_VAR_relay_public_key: ${{ secrets.RELAY_PUBLIC_KEY }}
@@ -154,7 +153,6 @@ jobs:
         env:
           GRAFANA_AUTH: ${{ steps.grafana-get-key.outputs.key }}
           TF_VAR_grafana_endpoint: ${{ steps.grafana-get-details.outputs.endpoint }}
-          TF_VAR_cloud_api_key: ${{ secrets.CLOUD_API_KEY }}
           TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
           TF_VAR_image_version: ${{ inputs.image_tag }}
           TF_VAR_relay_public_key: ${{ secrets.RELAY_PUBLIC_KEY }}

--- a/.github/workflows/ci_terraform.yml
+++ b/.github/workflows/ci_terraform.yml
@@ -124,7 +124,6 @@ jobs:
         env:
           GRAFANA_AUTH: ${{ steps.grafana-get-key.outputs.key }}
           TF_VAR_grafana_endpoint: ${{ steps.grafana-get-details.outputs.endpoint }}
-          TF_VAR_cloud_api_key: ${{ secrets.CLOUD_API_KEY }}
           TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
           TF_VAR_relay_public_key: ${{ secrets.RELAY_PUBLIC_KEY }}
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,17 +134,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,19 +869,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cerberus"
-version = "0.2.0"
-source = "git+https://github.com/WalletConnect/cerberus.git?tag=v0.5.0#bc1033ca9fa9d588d51237016354f69e0dcafafb"
-dependencies = [
- "async-trait",
- "once_cell",
- "regex",
- "reqwest",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,7 +1215,6 @@ name = "echo-server"
 version = "0.37.6"
 dependencies = [
  "a2",
- "async-recursion",
  "async-trait",
  "atty",
  "aws-config",
@@ -1249,7 +1224,6 @@ dependencies = [
  "base64 0.21.4",
  "build-info",
  "build-info-build",
- "cerberus",
  "chrono",
  "data-encoding",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,6 @@ is-variant-derive = { path = "crates/is-variant-derive" }
 once_cell = "1.15"
 pnet_datalink = "0.31"
 ipnet = "2.5"
-cerberus = { git = "https://github.com/WalletConnect/cerberus.git", tag = "v0.5.0" }
-async-recursion = "1.0.4"
 tap = "1.0.1"
 wiremock = "0.5.21"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,12 +81,6 @@ pub struct Config {
 
     #[cfg(feature = "geoblock")]
     pub blocked_countries: Vec<String>,
-
-    // Cloud
-    #[cfg(feature = "cloud")]
-    pub cloud_api_url: String,
-    #[cfg(feature = "cloud")]
-    pub cloud_api_key: String,
 }
 
 impl Config {

--- a/src/error.rs
+++ b/src/error.rs
@@ -151,9 +151,6 @@ pub enum Error {
     #[error("BatchCollector Error: {0}")]
     BatchCollector(String),
 
-    #[error(transparent)]
-    Registry(#[from] cerberus::registry::RegistryError),
-
     #[error("Invalid Project ID: {0}")]
     InvalidProjectId(String),
 
@@ -511,12 +508,6 @@ impl IntoResponse for Error {
                 ResponseError {
                     name: "o11y".to_string(),
                     message: "Internal error monitoring the request".to_string(),
-                },
-            ], vec![]),
-            Error::Registry(_) => crate::handlers::Response::new_failure(StatusCode::INTERNAL_SERVER_ERROR, vec![
-                ResponseError {
-                    name: "internal_api_failed".to_string(),
-                    message: "Please check https://status.walletconnect.com as an internal API failed to resolve this request".to_string(),
                 },
             ], vec![]),
             Error::JWT(_) => crate::handlers::Response::new_failure(StatusCode::UNAUTHORIZED, vec![

--- a/src/handlers/delete_tenant.rs
+++ b/src/handlers/delete_tenant.rs
@@ -25,17 +25,11 @@ pub async fn handler(
     headers: HeaderMap,
 ) -> Result<Json<DeleteTenantResponse>, Error> {
     #[cfg(feature = "cloud")]
-    let verification_res = validate_tenant_request(
-        &state.registry_client,
-        &state.gotrue_client,
-        &headers,
-        id.clone(),
-        None,
-    )
-    .await;
+    let verification_res =
+        validate_tenant_request(&state.jwt_validation_client, &headers, id.clone()).await;
 
     #[cfg(not(feature = "cloud"))]
-    let verification_res = validate_tenant_request(&state.gotrue_client, &headers);
+    let verification_res = validate_tenant_request(&state.jwt_validation_client, &headers);
 
     if let Err(e) = verification_res {
         error!(

--- a/src/handlers/get_tenant.rs
+++ b/src/handlers/get_tenant.rs
@@ -30,17 +30,11 @@ pub async fn handler(
     headers: HeaderMap,
 ) -> Result<Json<GetTenantResponse>, Error> {
     #[cfg(feature = "cloud")]
-    let verification_res = validate_tenant_request(
-        &state.registry_client,
-        &state.gotrue_client,
-        &headers,
-        id.clone(),
-        None,
-    )
-    .await;
+    let verification_res =
+        validate_tenant_request(&state.jwt_validation_client, &headers, id.clone()).await;
 
     #[cfg(not(feature = "cloud"))]
-    let verification_res = validate_tenant_request(&state.gotrue_client, &headers);
+    let verification_res = validate_tenant_request(&state.jwt_validation_client, &headers);
 
     if let Err(e) = verification_res {
         error!(

--- a/src/jwt_validation/mod.rs
+++ b/src/jwt_validation/mod.rs
@@ -5,28 +5,26 @@ use {
 };
 
 #[derive(Serialize, Deserialize)]
-pub struct GoTrueClaims {
+pub struct Claims {
     pub sub: String,
-    pub aud: String,
-    pub role: String,
 }
 
 #[derive(Clone)]
-pub struct GoTrueClient {
+pub struct JwtValidationClient {
     decoding_key: DecodingKey,
     validation: Validation,
 }
 
-impl GoTrueClient {
-    pub fn new(jwt_secret: String) -> GoTrueClient {
-        GoTrueClient {
+impl JwtValidationClient {
+    pub fn new(jwt_secret: String) -> JwtValidationClient {
+        JwtValidationClient {
             decoding_key: DecodingKey::from_secret(jwt_secret.as_bytes()),
             validation: Validation::new(Algorithm::HS256),
         }
     }
 
-    pub fn is_valid_token(&self, jwt: String) -> Result<TokenData<GoTrueClaims>> {
-        Ok(jsonwebtoken::decode::<GoTrueClaims>(
+    pub fn is_valid_token(&self, jwt: String) -> Result<TokenData<Claims>> {
+        Ok(jsonwebtoken::decode::<Claims>(
             &jwt,
             &self.decoding_key,
             &self.validation,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub mod blob;
 pub mod config;
 pub mod error;
 pub mod handlers;
+pub mod jwt_validation;
 pub mod log;
 pub mod macros;
 pub mod metrics;
@@ -64,7 +65,6 @@ pub mod providers;
 pub mod relay;
 pub mod state;
 pub mod stores;
-pub mod supabase;
 
 const PG_CONNECTION_POOL_SIZE: u32 = 100;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "cloud")]
-use cerberus::registry::RegistryHttpClient;
 use {
     crate::{
         config::Config,
@@ -16,7 +14,7 @@ use {
 #[cfg(feature = "analytics")]
 use crate::analytics::PushAnalytics;
 #[cfg(feature = "multitenant")]
-use crate::supabase::GoTrueClient;
+use crate::jwt_validation::JwtValidationClient;
 
 pub type ClientStoreArc = Arc<dyn ClientStore + Send + Sync + 'static>;
 pub type NotificationStoreArc = Arc<dyn NotificationStore + Send + Sync + 'static>;
@@ -29,8 +27,6 @@ pub trait State {
     fn notification_store(&self) -> NotificationStoreArc;
     fn tenant_store(&self) -> TenantStoreArc;
     fn relay_client(&self) -> RelayClient;
-    #[cfg(feature = "cloud")]
-    fn registry_client(&self) -> RegistryHttpClient;
     fn is_multitenant(&self) -> bool;
     fn validate_signatures(&self) -> bool;
 }
@@ -46,10 +42,8 @@ pub struct AppState {
     pub notification_store: NotificationStoreArc,
     pub tenant_store: TenantStoreArc,
     pub relay_client: RelayClient,
-    #[cfg(feature = "cloud")]
-    pub registry_client: RegistryHttpClient,
     #[cfg(feature = "multitenant")]
-    pub gotrue_client: GoTrueClient,
+    pub jwt_validation_client: JwtValidationClient,
     pub public_ip: Option<IpAddr>,
     is_multitenant: bool,
     pub geoblock: Option<GeoBlockLayer<Arc<MaxMindResolver>>>,
@@ -75,9 +69,6 @@ pub fn new_state(
     #[cfg(not(feature = "multitenant"))]
     let is_multitenant = false;
 
-    #[cfg(feature = "cloud")]
-    let (cloud_url, cloud_api_key) = (config.cloud_api_url.clone(), config.cloud_api_key.clone());
-
     #[cfg(feature = "multitenant")]
     let jwt_secret = config.jwt_secret.clone();
 
@@ -97,10 +88,8 @@ pub fn new_state(
         notification_store,
         tenant_store,
         relay_client: RelayClient::new(config.relay_public_key)?,
-        #[cfg(feature = "cloud")]
-        registry_client: RegistryHttpClient::new(cloud_url, cloud_api_key.as_str())?,
         #[cfg(feature = "multitenant")]
-        gotrue_client: GoTrueClient::new(jwt_secret),
+        jwt_validation_client: JwtValidationClient::new(jwt_secret),
         public_ip,
         is_multitenant,
         geoblock: None,
@@ -138,11 +127,6 @@ impl State for Arc<AppState> {
 
     fn relay_client(&self) -> RelayClient {
         self.relay_client.clone()
-    }
-
-    #[cfg(feature = "cloud")]
-    fn registry_client(&self) -> RegistryHttpClient {
-        self.registry_client.clone()
     }
 
     fn is_multitenant(&self) -> bool {

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -93,7 +93,6 @@ No outputs.
   | Name | Description | Type | Default | Required |
   |------|-------------|------|---------|:--------:|
       | <a name="input_azs"></a> [azs](#input\_azs) | n/a |  <pre lang="json">list(string)</pre> |  <pre lang="json">[<br>  "eu-central-1a",<br>  "eu-central-1b",<br>  "eu-central-1c"<br>]</pre> |  no |
-      | <a name="input_cloud_api_key"></a> [cloud\_api\_key](#input\_cloud\_api\_key) | n/a |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
       | <a name="input_geoip_db_key"></a> [geoip\_db\_key](#input\_geoip\_db\_key) | The key to the GeoIP database |  <pre lang="json">string</pre> |  <pre lang="json">"GeoLite2-City.mmdb"</pre> |  no |
       | <a name="input_grafana_endpoint"></a> [grafana\_endpoint](#input\_grafana\_endpoint) | n/a |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
       | <a name="input_image_version"></a> [image\_version](#input\_image\_version) | n/a |  <pre lang="json">string</pre> |  <pre lang="json">""</pre> |  no |

--- a/terraform/ecs/README.md
+++ b/terraform/ecs/README.md
@@ -31,8 +31,6 @@ No modules.
       | <a name="input_backup_acm_certificate_arn"></a> [backup\_acm\_certificate\_arn](#input\_backup\_acm\_certificate\_arn) | n/a |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
       | <a name="input_backup_fqdn"></a> [backup\_fqdn](#input\_backup\_fqdn) | n/a |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
       | <a name="input_backup_route53_zone_id"></a> [backup\_route53\_zone\_id](#input\_backup\_route53\_zone\_id) | n/a |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
-      | <a name="input_cloud_api_key"></a> [cloud\_api\_key](#input\_cloud\_api\_key) | n/a |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
-      | <a name="input_cloud_api_url"></a> [cloud\_api\_url](#input\_cloud\_api\_url) | n/a |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
       | <a name="input_cpu"></a> [cpu](#input\_cpu) | n/a |  <pre lang="json">number</pre> |  <pre lang="json">n/a</pre> |  yes |
       | <a name="input_database_url"></a> [database\_url](#input\_database\_url) | n/a |  <pre lang="json">string</pre> |  <pre lang="json">n/a</pre> |  yes |
       | <a name="input_desired_count"></a> [desired\_count](#input\_desired\_count) | n/a |  <pre lang="json">number</pre> |  <pre lang="json">n/a</pre> |  yes |

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -92,9 +92,6 @@ resource "aws_ecs_task_definition" "app_task_definition" {
 
         { name = "BLOCKED_COUNTRIES", value = "KP,IR,CU,SY,RU" },
 
-        { name = "CLOUD_API_KEY", value = var.cloud_api_key },
-        { name = "CLOUD_API_URL", value = var.cloud_api_url },
-
         { name = "JWT_SECRET", value = var.jwt_secret },
         { name = "RELAY_PUBLIC_KEY", value = var.relay_public_key }
       ],

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -124,15 +124,6 @@ variable "autoscaling_min_capacity" {
   type = number
 }
 
-variable "cloud_api_key" {
-  type      = string
-  sensitive = true
-}
-
-variable "cloud_api_url" {
-  type = string
-}
-
 variable "jwt_secret" {
   type      = string
   sensitive = true

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -175,9 +175,6 @@ module "ecs" {
   analytics_geoip_db_bucket_name = local.geoip_db_bucket_name
   analytics_geoip_db_key         = var.geoip_db_key
 
-  cloud_api_key = var.cloud_api_key
-  cloud_api_url = "https://registry.walletconnect.com/"
-
   jwt_secret       = var.jwt_secret
   relay_public_key = var.relay_public_key
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,11 +28,6 @@ variable "geoip_db_key" {
   default     = "GeoLite2-City.mmdb"
 }
 
-variable "cloud_api_key" {
-  type      = string
-  sensitive = true
-}
-
 variable "jwt_secret" {
   type      = string
   sensitive = true

--- a/tests/context/mod.rs
+++ b/tests/context/mod.rs
@@ -76,10 +76,6 @@ impl TestContext for ConfigContext {
             analytics_export_bucket: "example-bucket".to_string(),
             is_test: true,
             cors_allowed_origins: vec!["*".to_string()],
-            #[cfg(feature = "cloud")]
-            cloud_api_url: "https://example.com".to_string(),
-            #[cfg(feature = "cloud")]
-            cloud_api_key: "n/a".to_string(),
             #[cfg(feature = "geoblock")]
             blocked_countries: vec![],
         };

--- a/tests/functional/multitenant/apns.rs
+++ b/tests/functional/multitenant/apns.rs
@@ -21,8 +21,6 @@ async fn tenant_update_apns_valid_token(ctx: &mut EchoServerContext) {
         .as_secs() as usize;
     let token_claims = ClaimsForValidation {
         sub: tenant_id.clone(),
-        aud: "authenticated".to_string(),
-        role: "authenticated".to_string(),
         exp: unix_timestamp + 60 * 60, // Add an hour for expiration
     };
     let jwt_token = encode(

--- a/tests/functional/multitenant/fcm.rs
+++ b/tests/functional/multitenant/fcm.rs
@@ -21,8 +21,6 @@ async fn tenant_update_fcm_valid(ctx: &mut EchoServerContext) {
         .as_secs() as usize;
     let token_claims = ClaimsForValidation {
         sub: random_tenant_id.clone(),
-        aud: "authenticated".to_string(),
-        role: "authenticated".to_string(),
         exp: unix_timestamp + 60 * 60, // Add an hour for expiration
     };
     let jwt_token = encode(

--- a/tests/functional/multitenant/mod.rs
+++ b/tests/functional/multitenant/mod.rs
@@ -9,8 +9,6 @@ mod tenancy;
 #[derive(Serialize)]
 pub struct ClaimsForValidation {
     sub: String,
-    aud: String,
-    role: String,
     exp: usize,
 }
 

--- a/tests/functional/multitenant/tenancy.rs
+++ b/tests/functional/multitenant/tenancy.rs
@@ -21,8 +21,6 @@ async fn tenant_register_get_delete(ctx: &mut EchoServerContext) {
         .as_secs() as usize;
     let token_claims = ClaimsForValidation {
         sub: random_tenant_id.clone(),
-        aud: "authenticated".to_string(),
-        role: "authenticated".to_string(),
         exp: unix_timestamp + 60 * 60, // Add an hour for expiration
     };
     let jwt_token = encode(


### PR DESCRIPTION
# Description

Uses the new Cloud authentication mechanism introduced in [this PR](https://github.com/WalletConnect/cloud-app/pull/1094). [Slack conversation](https://walletconnect.slack.com/archives/C03SPNLG39P/p1713271392759799)

Instead of a Supabase user JWT being provided to Push Server, Push Server authenticating this JWT with a shared secret from Cloud, and then Push Server checking with Push Server if the user has access to the tenant... now the authorization of the user's access to the project/tenant is completely offloaded to Cloud and all Push Server does now is checks a JWT signature. This JWT is now signed by Cloud app with a different shared secret and has a TTL of 30s rather than being the same one used for all user authentication in Cloud.

Resolves that Cloud currently is not able to configure Push Server due to a breaking change that was overlooked.

Remaining work:
- [x] Update `JWT_SECRET` to new secret
- [x] Remove `CLOUD_API_SECRET` secret

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update