### PR TITLE
fix: separate staging and prod JWT secrets

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -83,7 +83,7 @@ jobs:
         env:
           GRAFANA_AUTH: ${{ steps.grafana-get-key.outputs.key }}
           TF_VAR_grafana_endpoint: ${{ steps.grafana-get-details.outputs.endpoint }}
-          TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
+          TF_VAR_jwt_secret: ${{ secrets.STAGING_JWT_SECRET }}
           TF_VAR_image_version: ${{ inputs.image_tag }}
           TF_VAR_relay_public_key: ${{ secrets.RELAY_PUBLIC_KEY }}
         with:
@@ -153,7 +153,7 @@ jobs:
         env:
           GRAFANA_AUTH: ${{ steps.grafana-get-key.outputs.key }}
           TF_VAR_grafana_endpoint: ${{ steps.grafana-get-details.outputs.endpoint }}
-          TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
+          TF_VAR_jwt_secret: ${{ secrets.PROD_JWT_SECRET }}
           TF_VAR_image_version: ${{ inputs.image_tag }}
           TF_VAR_relay_public_key: ${{ secrets.RELAY_PUBLIC_KEY }}
         with:


### PR DESCRIPTION
# Description

Separate JWT_SECRET for staging and prod environments. [Slack conversation](https://walletconnect.slack.com/archives/C03SPNLG39P/p1713816485853389?thread_ts=1713271392.759799&cid=C03SPNLG39P)

- [x] `STAGING_JWT_SECRET` secret crated in GitHub
- [x] `PROD_JWT_SECRET` secret crated in GitHub

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update