### PR TITLE
chore: bump a2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,8 +5,7 @@ version = 3
 [[package]]
 name = "a2"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9113bcfcb2f288f0619d47d84f712ddad87b4d0a79245b2d61ffe13960fb8ac8"
+source = "git+https://github.com/threema-donat/a2.git?branch=add_timeout#b938e2dce24a88b66f3380fab53df2a0aace6452"
 dependencies = [
  "base64 0.21.4",
  "erased-serde",
@@ -16,11 +15,13 @@ dependencies = [
  "hyper-rustls 0.26.0",
  "hyper-util",
  "openssl",
+ "parking_lot 0.12.1",
  "rustls 0.22.4",
  "rustls-pemfile 2.1.1",
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,9 @@ version = 3
 
 [[package]]
 name = "a2"
-version = "0.9.0"
-source = "git+https://github.com/threema-donat/a2.git?branch=add_timeout#b938e2dce24a88b66f3380fab53df2a0aace6452"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f279fc8b1f1a64138f0f4b9cda9be488ae35bc2f8556c7ffe60730f1c07d005a"
 dependencies = [
  "base64 0.21.4",
  "erased-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ tracing-opentelemetry = "0.18"
 atty = "0.2"
 
 # Push
-a2 = { version = "0.9.0", features = ["tracing", "openssl"] }
+a2 = { git = "https://github.com/threema-donat/a2.git", branch = "add_timeout", features = ["tracing", "openssl"] }
 fcm = "0.9"
 
 # Signature validation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ tracing-opentelemetry = "0.18"
 atty = "0.2"
 
 # Push
-a2 = { git = "https://github.com/threema-donat/a2.git", branch = "add_timeout", features = ["tracing", "openssl"] }
+a2 = { version = "0.10.0", features = ["tracing", "openssl"] }
 fcm = "0.9"
 
 # Signature validation

--- a/src/handlers/register_client.rs
+++ b/src/handlers/register_client.rs
@@ -78,9 +78,9 @@ pub async fn handler(
         return Err(EmptyField("token".to_string()));
     }
 
-    let mut client_id = body.client_id.to_string();
-
-    client_id = client_id
+    let client_id = body
+        .client_id
+        .as_ref()
         .trim_start_matches(DECENTRALIZED_IDENTIFIER_PREFIX)
         .to_owned();
 

--- a/src/handlers/update_apns.rs
+++ b/src/handlers/update_apns.rs
@@ -6,6 +6,7 @@ use {
         state::AppState,
         stores::tenant::{TenantApnsUpdateAuth, TenantApnsUpdateParams},
     },
+    a2::ClientConfig,
     axum::{
         extract::{Multipart, Path, State},
         http::HeaderMap,
@@ -220,7 +221,7 @@ pub async fn handler(
                 match a2::Client::certificate(
                     &mut std::io::Cursor::new(decoded),
                     &apns_certificate_password,
-                    a2::Endpoint::Sandbox,
+                    ClientConfig::new(a2::Endpoint::Sandbox),
                 ) {
                     Ok(_) => Ok(()),
                     Err(e) => {
@@ -240,7 +241,7 @@ pub async fn handler(
                     &mut std::io::Cursor::new(decoded),
                     apns_key_id,
                     apns_team_id,
-                    a2::Endpoint::Sandbox,
+                    ClientConfig::new(a2::Endpoint::Sandbox),
                 ) {
                     Ok(_) => Ok(()),
                     Err(e) => {

--- a/src/providers/apns.rs
+++ b/src/providers/apns.rs
@@ -1,7 +1,7 @@
 use {
     super::{LegacyPushMessage, PushMessage, RawPushMessage},
     crate::{blob::DecryptedPayloadBlob, error::Error, providers::PushProvider},
-    a2::{ErrorReason, NotificationBuilder, NotificationOptions},
+    a2::{ClientConfig, ErrorReason, NotificationBuilder, NotificationOptions},
     async_trait::async_trait,
     std::io::Read,
     tracing::{debug, info, instrument, warn},
@@ -24,7 +24,7 @@ impl ApnsProvider {
         R: Read,
     {
         Ok(ApnsProvider {
-            client: a2::Client::certificate(cert, password.as_str(), endpoint)?,
+            client: a2::Client::certificate(cert, password.as_str(), ClientConfig::new(endpoint))?,
             topic,
         })
     }
@@ -40,7 +40,7 @@ impl ApnsProvider {
         R: Read,
     {
         Ok(ApnsProvider {
-            client: a2::Client::token(pkcs8_pem, key_id, team_id, endpoint)?,
+            client: a2::Client::token(pkcs8_pem, key_id, team_id, ClientConfig::new(endpoint))?,
             topic,
         })
     }

--- a/src/providers/fcm.rs
+++ b/src/providers/fcm.rs
@@ -105,7 +105,7 @@ impl Clone for FcmProvider {
     }
 
     fn clone_from(&mut self, source: &Self) {
-        self.api_key = source.api_key.clone();
+        self.api_key.clone_from(&source.api_key);
         self.client = fcm::Client::new();
     }
 }


### PR DESCRIPTION
# Description

Updates to lasted version of `a2` lib which has https://github.com/WalletConnect/a2/pull/81 incorporated

Fixes some clippy errors

## How Has This Been Tested?

Existing tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update