### PR TITLE
fix: push payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "fcm"
 version = "0.10.0"
-source = "git+https://github.com/WalletConnect/fcm-rust.git?branch=feat/key-not-from-file#39d3533af00460041999afc2e94b8bb39ecea081"
+source = "git+https://github.com/WalletConnect/fcm-rust.git?branch=feat/key-not-from-file#da38296727bd223293d6a5f558f952f76d8134e1"
 dependencies = [
  "chrono",
  "erased-serde 0.4.4",


### PR DESCRIPTION
# Description

Fixes:
- New API strictly only allows strings [Slack conversation](https://walletconnect.slack.com/archives/C03SPNLG39P/p1715797571247759)
- `content-available` not set

Resolves #323

## How Has This Been Tested?

Manually

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update