### PR TITLE
feat: per-IP rate limiting

### DIFF
--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,1 +1,2 @@
+pub mod rate_limit;
 pub mod validate_signature;

--- a/src/middleware/rate_limit.rs
+++ b/src/middleware/rate_limit.rs
@@ -1,0 +1,63 @@
+use crate::{networking, state::AppState};
+use axum::{
+    extract::Request,
+    extract::State,
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use moka::future::Cache;
+use std::{net::IpAddr, sync::Arc};
+use tokio::time::Duration;
+use tracing::error;
+
+pub const MAX_REQUESTS_PER_SEC: u32 = 10;
+
+#[derive(Clone)]
+pub struct RateLimiter {
+    cache: Arc<Cache<IpAddr, u32>>,
+    max_requests: u32,
+}
+
+impl RateLimiter {
+    pub fn new(max_requests: u32, window: Duration) -> Self {
+        Self {
+            cache: Arc::new(Cache::builder().time_to_live(window).build()),
+            max_requests,
+        }
+    }
+}
+
+/// Rate limit middleware that limits the number of requests per second from a single IP address and
+/// uses in-memory caching to store the number of requests.
+pub async fn rate_limit_middleware(
+    State(state): State<Arc<AppState>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let headers = req.headers().clone();
+    let client_ip = match networking::get_forwarded_ip(headers.clone()) {
+        Some(ip) => ip,
+        None => {
+            error!(
+                "Failed to get forwarded IP from request in rate limiting middleware. Skipping the \
+                 rate-limiting."
+            );
+            // We are skipping the drop to the connect info IP address here, because we are
+            // using the Load Balancer and if any issues with the X-Forwarded-IP header, we
+            // will rate-limit the LB IP address.
+            return next.run(req).await;
+        }
+    };
+
+    let rate_limiter = &state.rate_limit;
+    let mut rate_limit = rate_limiter.cache.get_with(client_ip, async { 0 }).await;
+
+    if rate_limit < rate_limiter.max_requests {
+        rate_limit += 1;
+        rate_limiter.cache.insert(client_ip, rate_limit).await;
+        next.run(req).await
+    } else {
+        (StatusCode::TOO_MANY_REQUESTS, "Too many requests").into_response()
+    }
+}

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -1,4 +1,4 @@
-use {ipnet::IpNet, std::net::IpAddr};
+use {axum::http::HeaderMap, ipnet::IpNet, std::net::IpAddr};
 
 #[derive(thiserror::Error, Debug)]
 pub enum NetworkInterfaceError {
@@ -64,4 +64,12 @@ fn is_public_ip_addr(addr: IpAddr) -> bool {
     });
 
     RESERVED_NETWORKS.iter().all(|range| !range.contains(&addr))
+}
+
+pub fn get_forwarded_ip(headers: HeaderMap) -> Option<IpAddr> {
+    headers
+        .get("X-Forwarded-For")
+        .and_then(|header| header.to_str().ok())
+        .and_then(|header| header.split(',').next())
+        .and_then(|client_ip| client_ip.trim().parse::<IpAddr>().ok())
 }


### PR DESCRIPTION
# Description

This PR implements the simple per-IP rate limiting. The rate limiter is implemented in an Axum middleware using the in-memory `Moka` caching. The default requests per second limit is 10 req/sec which should be enough for the legit users and cut flood requests. Only the `X-Forwarded` IP is used to prevent blocking the Load Balancer IP.

Resolves #304 

## How Has This Been Tested?

* Manual testing,
* Basic [flood integration test](https://github.com/WalletConnect/push-server/pull/327/files#diff-29ee1e76a6651d33c3e1a5117e948675ccda1e60165c885696a9accdc1bf0bb9R72).

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update