### PR TITLE
fix: client registrations chart

### DIFF
--- a/src/handlers/delete_client.rs
+++ b/src/handlers/delete_client.rs
@@ -1,6 +1,5 @@
 use {
     crate::{
-        decrement_counter,
         error::{Error::InvalidAuthentication, Result},
         handlers::{authenticate_client, Response, DECENTRALIZED_IDENTIFIER_PREFIX},
         log::prelude::*,
@@ -62,8 +61,6 @@ pub async fn handler(
         client_id = %client_to_be_deleted,
         "deleted client"
     );
-
-    decrement_counter!(state.metrics, registered_clients);
 
     Ok(Response::default())
 }

--- a/src/handlers/delete_tenant.rs
+++ b/src/handlers/delete_tenant.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        decrement_counter, error::Error, handlers::validate_tenant_request, log::prelude::*,
-        state::AppState,
-    },
+    crate::{error::Error, handlers::validate_tenant_request, log::prelude::*, state::AppState},
     axum::{
         extract::{Path, State},
         http::HeaderMap,
@@ -41,8 +38,6 @@ pub async fn handler(
     }
 
     state.tenant_store.delete_tenant(&id).await?;
-
-    decrement_counter!(state.metrics, registered_tenants);
 
     debug!(
         tenant_id = %id,

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,7 +1,7 @@
 use {
     crate::error::{Error, Result},
     opentelemetry::{
-        metrics::{Counter, UpDownCounter},
+        metrics::Counter,
         sdk::{
             self,
             export::metrics::aggregation,
@@ -22,8 +22,8 @@ pub struct Metrics {
     pub sent_fcm_v1_notifications: Counter<u64>,
     pub sent_apns_notifications: Counter<u64>,
 
-    pub registered_clients: UpDownCounter<i64>,
-    pub registered_tenants: UpDownCounter<i64>,
+    pub registered_clients: Counter<u64>,
+    pub registered_tenants: Counter<u64>,
 
     pub tenant_apns_updates: Counter<u64>,
     pub tenant_fcm_updates: Counter<u64>,
@@ -54,12 +54,12 @@ impl Metrics {
         let meter = opentelemetry::global::meter("echo-server");
 
         let clients_counter = meter
-            .i64_up_down_counter("registered_clients")
+            .u64_counter("registered_clients")
             .with_description("The number of currently registered clients")
             .init();
 
         let tenants_counter = meter
-            .i64_up_down_counter("registered_tenants")
+            .u64_counter("registered_tenants")
             .with_description("The number of currently registered tenants")
             .init();
 

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -150,71 +150,6 @@ resource "grafana_dashboard" "at_a_glance" {
         "type" : "stat"
       },
       {
-        "datasource" : {
-          "type" : "prometheus",
-          "uid" : grafana_data_source.prometheus.uid
-        },
-        "fieldConfig" : {
-          "defaults" : {
-            "color" : {
-              "mode" : "thresholds"
-            },
-            "mappings" : [],
-            "thresholds" : {
-              "mode" : "absolute",
-              "steps" : [
-                {
-                  "color" : "green",
-                  "value" : null
-                },
-                {
-                  "color" : "red",
-                  "value" : 80
-                }
-              ]
-            }
-          },
-          "overrides" : []
-        },
-        "gridPos" : {
-          "h" : 8,
-          "w" : 10,
-          "x" : 11,
-          "y" : 0
-        },
-        "id" : 16,
-        "options" : {
-          "colorMode" : "value",
-          "graphMode" : "area",
-          "justifyMode" : "auto",
-          "orientation" : "auto",
-          "reduceOptions" : {
-            "calcs" : [
-              "lastNotNull"
-            ],
-            "fields" : "",
-            "values" : false
-          },
-          "textMode" : "auto"
-        },
-        "pluginVersion" : "8.4.7",
-        "targets" : [
-          {
-            "datasource" : {
-              "type" : "prometheus",
-              "uid" : grafana_data_source.prometheus.uid
-            },
-            "exemplar" : true,
-            "expr" : "sum(rate(registered_clients{}[1h]))",
-            "interval" : "",
-            "legendFormat" : "",
-            "refId" : "A"
-          }
-        ],
-        "title" : "Client Registrations per Hour",
-        "type" : "stat"
-      },
-      {
         "gridPos" : {
           "h" : 1,
           "w" : 24,
@@ -417,13 +352,13 @@ resource "grafana_dashboard" "at_a_glance" {
               "uid" : grafana_data_source.prometheus.uid
             },
             "exemplar" : true,
-            "expr" : "sum(increase(registered_clients{}[1h]))",
+            "expr" : "sum(rate(registered_clients{}[$__rate_interval]))",
             "interval" : "",
             "legendFormat" : "",
             "refId" : "Clients"
           }
         ],
-        "title" : "Registered Clients past 1h",
+        "title" : "Client registration rate",
         "type" : "timeseries"
       },
       {


### PR DESCRIPTION
# Description

This chart is confusing since it shows registrations over the past hour, but per sec or per rate interval is really what we care about.

Also it was an up/down counter which was strange and the Grafana didn't like with that (it was warning). Moving to only-up counter to get us closer to a req/s i.e. understanding of load vs the arbitrary amount of registrations we currently have.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update