### PR TITLE
fix: upgrade otel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,6 @@ VALIDATE_SIGNATURES=true
 # We're using separate log levels for stderr and telemetry. Note: telemetry
 # exports require 'trace' log level.
 LOG_LEVEL=info,echo-server=info
-LOG_LEVEL_OTEL=info,echo-server=trace
 
 # Multi-Tenancy
 TENANT_DATABASE_URL=
@@ -24,9 +23,6 @@ JWT_SECRET=
 CORS_ALLOWED_ORIGINS=*
 
 # Telemetry
-# OTLP ENV also supported e.g.
-# OTEL_SERVICE_NAME=echo-server
-OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 TELEMETRY_PROMETHEUS_PORT=3001
 
 # FCM

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,28 +158,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.61",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,40 +570,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
- "axum-core 0.4.3",
+ "axum-core",
  "bytes",
  "futures-util",
  "http 1.1.0",
@@ -659,26 +609,9 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e7c467bdcd2bd982ce5c8742a1a178aba7b03db399fd18f5d5d438f5aa91cb4"
 dependencies = [
- "axum 0.7.5",
+ "axum",
  "forwarded-header-value",
  "serde",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -1377,7 +1310,7 @@ dependencies = [
  "atty",
  "aws-config",
  "aws-sdk-s3",
- "axum 0.7.5",
+ "axum",
  "axum-client-ip",
  "base64 0.21.7",
  "build-info",
@@ -1397,13 +1330,9 @@ dependencies = [
  "jsonwebtoken",
  "moka",
  "once_cell",
- "opentelemetry 0.18.0",
- "opentelemetry-otlp",
- "opentelemetry-prometheus 0.11.0",
  "parquet",
  "parquet_derive",
  "pnet_datalink",
- "prometheus",
  "rand",
  "random-string",
  "relay_rpc",
@@ -1633,12 +1562,6 @@ name = "finl_unicode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -2009,15 +1932,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "http"
 version = "0.1.0"
 source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.11.1#ec503450d9671a5546bf8887f17723b9a02e0d36"
@@ -2176,18 +2090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.28",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
-]
-
-[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2336,15 +2238,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -2521,7 +2414,7 @@ source = "git+https://github.com/WalletConnect/utils-rs.git?tag=v0.11.1#ec503450
 dependencies = [
  "once_cell",
  "opentelemetry 0.22.0",
- "opentelemetry-prometheus 0.15.0",
+ "opentelemetry-prometheus",
  "opentelemetry_sdk 0.22.1",
  "pin-project",
  "prometheus",
@@ -2616,12 +2509,6 @@ dependencies = [
  "spin 0.9.8",
  "version_check",
 ]
-
-[[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "native-tls"
@@ -2845,35 +2732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-otlp"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c928609d087790fc936a1067bdc310ae702bdf3b090c3f281b713622c8bbde"
-dependencies = [
- "async-trait",
- "futures",
- "futures-util",
- "http 0.2.12",
- "opentelemetry 0.18.0",
- "opentelemetry-proto",
- "prost",
- "thiserror",
- "tokio",
- "tonic",
-]
-
-[[package]]
-name = "opentelemetry-prometheus"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c3d833835a53cf91331d2cfb27e9121f5a95261f31f08a1f79ab31688b8da8"
-dependencies = [
- "opentelemetry 0.18.0",
- "prometheus",
- "protobuf",
-]
-
-[[package]]
 name = "opentelemetry-prometheus"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2884,20 +2742,6 @@ dependencies = [
  "opentelemetry_sdk 0.22.1",
  "prometheus",
  "protobuf",
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61a2f56df5574508dd86aaca016c917489e589ece4141df1b5e349af8d66c28"
-dependencies = [
- "futures",
- "futures-util",
- "opentelemetry 0.18.0",
- "prost",
- "tonic",
- "tonic-build",
 ]
 
 [[package]]
@@ -2934,8 +2778,6 @@ dependencies = [
  "percent-encoding",
  "rand",
  "thiserror",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -3112,16 +2954,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.2.6",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3240,16 +3072,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3295,60 +3117,6 @@ dependencies = [
  "parking_lot 0.12.2",
  "protobuf",
  "thiserror",
-]
-
-[[package]]
-name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
-dependencies = [
- "bytes",
- "heck",
- "itertools 0.10.5",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 1.0.109",
- "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
-dependencies = [
- "prost",
 ]
 
 [[package]]
@@ -4135,7 +3903,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
 dependencies = [
- "itertools 0.12.1",
+ "itertools",
  "nom",
  "unicode_categories",
 ]
@@ -4531,16 +4299,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4607,51 +4365,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.6.20",
- "base64 0.13.1",
- "bytes",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost",
- "prost-derive",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4659,13 +4372,9 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
- "slab",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4746,16 +4455,6 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -5064,18 +4763,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,12 +48,6 @@ envy = "0.4"
 # Build-time info
 build-info = "0.0"
 
-# Metrics & Traces
-prometheus-core = { package = "prometheus", version = "0.13" }
-opentelemetry = { version = "0.18", features = ["metrics", "rt-tokio"] }
-opentelemetry-prometheus = "0.11"
-opentelemetry-otlp = "0.11"
-
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "parking_lot"] }

--- a/docker-compose.multi-tenant.yml
+++ b/docker-compose.multi-tenant.yml
@@ -1,10 +1,5 @@
 version: '3.9'
 services:
-  jaeger:
-    image: jaegertracing/opentelemetry-all-in-one:latest
-    ports:
-      - "3001:16686"
-
   postgres:
     image: postgres
     environment:
@@ -31,11 +26,6 @@ services:
       environment:
         - PORT=3000
         - LOG_LEVEL=info,echo-server=info
-        - LOG_LEVEL_OTEL=info,echo-server=trace
         - DATABASE_URL=postgres://postgres:root@postgres:5432/postgres
         - TENANT_DATABASE_URL=postgres://postgres:root@postgres-tenant:5433/postgres
-        - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
         - TELEMETRY_PROMETHEUS_PORT=3002
-        - OTEL_SERVICE_NAME=echo-server
-        - OTEL_RESOURCE_ATTRIBUTES=environment=dev,region=local,version=0.11.5
-        - OTEL_TRACES_SAMPLER=always_on

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,5 @@
 version: '3.9'
 services:
-  jaeger:
-    image: jaegertracing/opentelemetry-all-in-one:latest
-    ports:
-      - "3001:16686"
-
   postgres:
       image: postgres
       environment:
@@ -21,10 +16,5 @@ services:
       environment:
         - PORT=3000
         - LOG_LEVEL=info,echo-server=info
-        - LOG_LEVEL_OTEL=info,echo-server=trace
         - DATABASE_URL=postgres://postgres:root@postgres:5432/postgres
-        - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
         - TELEMETRY_PROMETHEUS_PORT=3002
-        - OTEL_SERVICE_NAME=echo-server
-        - OTEL_RESOURCE_ATTRIBUTES=environment=dev,region=local,version=0.11.5
-        - OTEL_TRACES_SAMPLER=always_on

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,6 @@ use {
     },
     axum::response::{IntoResponse, Response},
     hyper::StatusCode,
-    wc::metrics::otel::{metrics::MetricsError, trace::TraceError},
 };
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -16,12 +15,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     #[error(transparent)]
     Envy(#[from] envy::Error),
-
-    #[error(transparent)]
-    Trace(#[from] TraceError),
-
-    #[error(transparent)]
-    Metrics(#[from] MetricsError),
 
     #[error("Bad device token error: {0}")]
     BadDeviceToken(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ use {
     },
     axum::response::{IntoResponse, Response},
     hyper::StatusCode,
+    wc::metrics::otel::{metrics::MetricsError, trace::TraceError},
 };
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -17,13 +18,10 @@ pub enum Error {
     Envy(#[from] envy::Error),
 
     #[error(transparent)]
-    Trace(#[from] opentelemetry::trace::TraceError),
+    Trace(#[from] TraceError),
 
     #[error(transparent)]
-    Metrics(#[from] opentelemetry::metrics::MetricsError),
-
-    #[error(transparent)]
-    Prometheus(#[from] prometheus_core::Error),
+    Metrics(#[from] MetricsError),
 
     #[error("Bad device token error: {0}")]
     BadDeviceToken(String),

--- a/src/handlers/metrics.rs
+++ b/src/handlers/metrics.rs
@@ -1,18 +1,19 @@
 use {
-    crate::{error::Result, log::prelude::*, state::AppState},
-    axum::{extract::State, http::StatusCode},
-    std::sync::Arc,
-    tracing::instrument,
+    axum::response::IntoResponse, hyper::StatusCode, tracing::error, wc::metrics::ServiceMetrics,
 };
 
-#[instrument(skip_all, name = "metrics_handler")]
-pub async fn handler(State(state): State<Arc<AppState>>) -> Result<(StatusCode, String)> {
-    if let Some(metrics) = &state.metrics {
-        let exported = metrics.export()?;
-        Ok((StatusCode::OK, exported))
-    } else {
-        // No Metrics!
-        warn!("request for metrics while they are disabled");
-        Ok((StatusCode::BAD_REQUEST, "Metrics not enabled.".to_string()))
+pub async fn handler() -> impl IntoResponse {
+    let result = ServiceMetrics::export();
+
+    match result {
+        Ok(content) => (StatusCode::OK, content),
+        Err(e) => {
+            error!(?e, "Failed to parse metrics");
+
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to get metrics".to_string(),
+            )
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@ use {
     config::Config,
     hyper::http::Method,
     middleware::rate_limit::rate_limit_middleware,
-    opentelemetry::{sdk::Resource, KeyValue},
     sqlx::{
         postgres::{PgConnectOptions, PgPoolOptions},
         ConnectOptions,
@@ -156,13 +155,7 @@ pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Config) -> 
         .join(", ");
 
     if state.config.telemetry_prometheus_port.is_some() {
-        state.set_metrics(metrics::Metrics::new(Resource::new(vec![
-            KeyValue::new("service_name", "echo-server"),
-            KeyValue::new(
-                "service_version",
-                state.build_info.crate_info.version.clone().to_string(),
-            ),
-        ]))?);
+        state.set_metrics(metrics::Metrics::new());
     }
 
     let port = state.config.port;
@@ -236,9 +229,7 @@ pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Config) -> 
             );
 
         Router::new()
-            .route("/health", get(handlers::health::handler).layer(
-                axum::middleware::from_fn_with_state(state_arc.clone(), rate_limit_middleware),
-            ))
+            .route("/health", get(handlers::health::handler))
             .nest("/tenants", tenancy_routes.layer(
                 axum::middleware::from_fn_with_state(state_arc.clone(), rate_limit_middleware),
             ))
@@ -264,9 +255,7 @@ pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Config) -> 
 
     #[cfg(not(feature = "multitenant"))]
     let app = Router::new()
-        .route("/health", get(handlers::health::handler).layer(
-            axum::middleware::from_fn_with_state(state_arc.clone(), rate_limit_middleware),
-        ))
+        .route("/health", get(handlers::health::handler))
         .route(
             "/clients",
             post(handlers::single_tenant_wrappers::register_handler).layer(

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,10 +1,10 @@
 #[macro_export]
 macro_rules! increment_counter {
     ($state:ident$(.$property:ident)*, $metric:ident) => {{
-        use {opentelemetry::Context, tracing::debug};
+        use tracing::debug;
 
         if let Some(metrics) = &$state$(.$property)* {
-            metrics.$metric.add(&Context::current(), 1, &[]);
+            metrics.$metric.add(1, &[]);
             debug!("incremented `{}` counter", stringify!($metric));
         }
     }};
@@ -13,10 +13,10 @@ macro_rules! increment_counter {
 #[macro_export]
 macro_rules! decrement_counter {
     ($state:ident$(.$property:ident)*, $metric:ident) => {{
-        use {opentelemetry::Context, tracing::debug};
+        use tracing::debug;
 
         if let Some(metrics) = &$state$(.$property)* {
-            metrics.$metric.add(&Context::current(), -1, &[]);
+            metrics.$metric.add(-1, &[]);
             debug!("decremented `{}` counter", stringify!($metric));
         }
     }};

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -72,17 +72,10 @@ resource "aws_ecs_task_definition" "app_task_definition" {
         { name = "PORT", value = "8080" },
         { name = "PUBLIC_URL", value = "https://${var.fqdn}" },
         { name = "LOG_LEVEL", value = "info,echo-server=info" },
-        { name = "LOG_LEVEL_OTEL", value = "info,echo-server=trace" },
         { name = "DATABASE_URL", value = var.database_url },
         { name = "TENANT_DATABASE_URL", value = var.tenant_database_url },
         { name = "CORS_ALLOWED_ORIGINS", value = var.allowed_origins },
         { name = "TELEMETRY_PROMETHEUS_PORT", value = local.prometheus_port },
-
-        { name = "OTEL_SERVICE_NAME", value = var.app_name },
-        { name = "OTEL_RESOURCE_ATTRIBUTES", value = "environment=${var.environment},region=${var.region},version=${var.image_version}" },
-        { name = "OTEL_EXPORTER_OTLP_ENDPOINT", value = "http://localhost:4317" },
-        { name = "OTEL_TRACES_SAMPLER", value = "traceidratio" },
-        { name = "OTEL_TRACES_SAMPLER_ARG", value = tostring(var.telemetry_sample_ratio) },
 
         { name = "GEOIP_DB_BUCKET", value = var.analytics_geoip_db_bucket_name },
         { name = "GEOIP_DB_KEY", value = var.analytics_geoip_db_key },


### PR DESCRIPTION
# Description

There were some dependencies on old versions of OTEL which were making implementation of Histograms a little tricky. Removing these old versions.

This also removes OTEL tracing which I think doesn't even work anyway.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update