### PR TITLE
fix: validate step

### DIFF
--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -76,7 +76,7 @@ describe('Echo Server', () => {
 
     // Simulate flood of requests and check for rate-limited responses
     it('Rate limiting', async () => {
-      const url = `${BASE_URL}/health`
+      const url = `${BASE_URL}/rate_limit_test`
       const requests_to_send = 100;
       const promises = [];
       for (let i = 0; i < requests_to_send; i++) {
@@ -85,7 +85,7 @@ describe('Echo Server', () => {
         );
       }
       const results = await Promise.allSettled(promises);
-      
+
       let ok_statuses_counter = 0;
       let rate_limited_statuses_counter = 0;
       results.forEach((result) => {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -40,6 +40,7 @@ pub mod delete_tenant;
 #[cfg(feature = "multitenant")]
 pub mod get_tenant;
 pub mod health;
+pub mod rate_limit_test;
 #[cfg(feature = "multitenant")]
 pub mod update_apns;
 #[cfg(feature = "multitenant")]

--- a/src/handlers/rate_limit_test.rs
+++ b/src/handlers/rate_limit_test.rs
@@ -1,0 +1,5 @@
+use axum::{http::StatusCode, response::IntoResponse};
+
+pub async fn handler() -> impl IntoResponse {
+    StatusCode::OK.into_response()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,9 @@ pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Config) -> 
 
         Router::new()
             .route("/health", get(handlers::health::handler))
+            .route("/rate_limit_test", get(handlers::rate_limit_test::handler).layer(
+                axum::middleware::from_fn_with_state(state_arc.clone(), rate_limit_middleware),
+            ))
             .nest("/tenants", tenancy_routes.layer(
                 axum::middleware::from_fn_with_state(state_arc.clone(), rate_limit_middleware),
             ))
@@ -260,6 +263,9 @@ pub async fn bootstap(mut shutdown: broadcast::Receiver<()>, config: Config) -> 
     #[cfg(not(feature = "multitenant"))]
     let app = Router::new()
         .route("/health", get(handlers::health::handler))
+        .route("/rate_limit_test", get(handlers::rate_limit_test::handler).layer(
+            axum::middleware::from_fn_with_state(state_arc.clone(), rate_limit_middleware),
+        ))
         .route(
             "/clients",
             post(handlers::single_tenant_wrappers::register_handler).layer(


### PR DESCRIPTION
# Description

Fixes the [failing validate step](https://github.com/WalletConnect/push-server/actions/runs/9163157819/job/25192171641) because the `/health` rate limit was removed in https://github.com/WalletConnect/push-server/pull/334/files#r1606990241

Testing the rate limit should be done with a unit test, but adding this mock endpoint real quick to resolve the issue in the meantime.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update