### PR TITLE
fix: improve create client performance

### DIFF
--- a/src/stores/client.rs
+++ b/src/stores/client.rs
@@ -131,7 +131,11 @@ impl ClientStore for sqlx::PgPool {
             notification_query_builder.push(" and tenant_id = ");
             notification_query_builder.push_bind(existing_client.tenant_id);
             let notification_query = notification_query_builder.build();
+            let start = Instant::now();
             self.execute(notification_query).await?;
+            if let Some(metrics) = metrics {
+                metrics.postgres_query("create_client_delete_notification", start);
+            }
 
             let query = "
                 UPDATE public.clients

--- a/src/stores/client.rs
+++ b/src/stores/client.rs
@@ -54,6 +54,12 @@ impl ClientStore for sqlx::PgPool {
             pub tenant_id: String,
         }
 
+        let start = Instant::now();
+        let mut transaction = self.begin().await?;
+        if let Some(metrics) = metrics {
+            metrics.postgres_query("create_client_begin", start);
+        }
+
         let query = "
             SELECT *
             FROM public.clients
@@ -65,117 +71,127 @@ impl ClientStore for sqlx::PgPool {
         let res = sqlx::query_as::<sqlx::postgres::Postgres, ClientSelect>(query)
             .bind(id)
             .bind(client.token.clone())
-            .fetch_one(self)
+            .fetch_one(&mut transaction)
             .await;
         if let Some(metrics) = metrics {
             metrics.postgres_query("create_client_delete", start);
         }
 
         let existing_client = match res {
-            Err(sqlx::Error::RowNotFound) => {
-                let start = Instant::now();
-                let mut insert_query = sqlx::QueryBuilder::new(
-                    "INSERT INTO public.clients (id, tenant_id, push_type, device_token, always_raw)",
-                );
-                insert_query.push_values(
-                    vec![(
-                        id,
-                        tenant_id,
-                        client.push_type,
-                        client.token,
-                        client.always_raw,
-                    )],
-                    |mut b, client| {
-                        b.push_bind(client.0)
-                            .push_bind(client.1)
-                            .push_bind(client.2)
-                            .push_bind(client.3)
-                            .push_bind(client.4);
-                    },
-                );
-                insert_query.build().execute(self).await?;
-                if let Some(metrics) = metrics {
-                    metrics.postgres_query("create_client_insert", start);
-                }
-                return Ok(());
-            }
+            Err(sqlx::Error::RowNotFound) => None,
             Err(e) => return Err(e.into()),
-            Ok(row) => row,
+            Ok(row) => Some(row),
         };
 
-        if existing_client.id == id && existing_client.device_token != client.token {
-            let query = "
-                UPDATE public.clients
-                SET device_token = $2,
-                    push_type = $3,
-                    always_raw = $4,
-                    tenant_id = $5
-                WHERE id = $1
-            ";
-            let start = Instant::now();
-            sqlx::query(query)
-                .bind(id)
-                .bind(client.token)
-                .bind(client.push_type)
-                .bind(client.always_raw)
-                .bind(tenant_id)
-                .execute(self)
-                .await?;
-            if let Some(metrics) = metrics {
-                metrics.postgres_query("create_client_update_device_token", start);
-            }
-        } else if existing_client.device_token == client.token && existing_client.id != id {
-            let mut notification_query_builder =
-                sqlx::QueryBuilder::new("DELETE FROM public.notifications WHERE client_id = ");
-            notification_query_builder.push_bind(existing_client.id);
-            notification_query_builder.push(" and tenant_id = ");
-            notification_query_builder.push_bind(existing_client.tenant_id);
-            let notification_query = notification_query_builder.build();
-            let start = Instant::now();
-            self.execute(notification_query).await?;
-            if let Some(metrics) = metrics {
-                metrics.postgres_query("create_client_delete_notification", start);
-            }
+        if let Some(existing_client) = existing_client {
+            if existing_client.id == id && existing_client.device_token != client.token {
+                let query = "
+                    UPDATE public.clients
+                    SET device_token = $2,
+                        push_type = $3,
+                        always_raw = $4,
+                        tenant_id = $5
+                    WHERE id = $1
+                ";
+                let start = Instant::now();
+                sqlx::query(query)
+                    .bind(id)
+                    .bind(client.token)
+                    .bind(client.push_type)
+                    .bind(client.always_raw)
+                    .bind(tenant_id)
+                    .execute(&mut transaction)
+                    .await?;
+                if let Some(metrics) = metrics {
+                    metrics.postgres_query("create_client_update_device_token", start);
+                }
+            } else if existing_client.device_token == client.token && existing_client.id != id {
+                let query = "
+                    DELETE FROM public.notifications
+                    WHERE client_id = $1
+                          AND tenant_id = $2
+                ";
+                let start = Instant::now();
+                sqlx::query(query)
+                    .bind(existing_client.id)
+                    .bind(existing_client.tenant_id)
+                    .execute(&mut transaction)
+                    .await?;
+                if let Some(metrics) = metrics {
+                    metrics.postgres_query("create_client_delete_notifications", start);
+                }
 
-            let query = "
-                UPDATE public.clients
-                SET id = $2,
-                    push_type = $3,
-                    always_raw = $4,
-                    tenant_id = $5
-                WHERE device_token = $1
-            ";
-            let start = Instant::now();
-            sqlx::query(query)
-                .bind(client.token)
-                .bind(id)
-                .bind(client.push_type)
-                .bind(client.always_raw)
-                .bind(tenant_id)
-                .execute(self)
-                .await?;
-            if let Some(metrics) = metrics {
-                metrics.postgres_query("create_client_update_id", start);
+                let query = "
+                    UPDATE public.clients
+                    SET id = $2,
+                        push_type = $3,
+                        always_raw = $4,
+                        tenant_id = $5
+                    WHERE device_token = $1
+                ";
+                let start = Instant::now();
+                sqlx::query(query)
+                    .bind(client.token)
+                    .bind(id)
+                    .bind(client.push_type)
+                    .bind(client.always_raw)
+                    .bind(tenant_id)
+                    .execute(&mut transaction)
+                    .await?;
+                if let Some(metrics) = metrics {
+                    metrics.postgres_query("create_client_update_id", start);
+                }
+            } else {
+                let query = "
+                    UPDATE public.clients
+                    SET push_type = $2,
+                        always_raw = $3,
+                        tenant_id = $4
+                    WHERE id = $1
+                ";
+                let start = Instant::now();
+                sqlx::query(query)
+                    .bind(id)
+                    .bind(client.push_type)
+                    .bind(client.always_raw)
+                    .bind(tenant_id)
+                    .execute(&mut transaction)
+                    .await?;
+                if let Some(metrics) = metrics {
+                    metrics.postgres_query("create_client_update_id", start);
+                }
             }
         } else {
-            let query = "
-                UPDATE public.clients
-                SET push_type = $2,
-                    always_raw = $3,
-                    tenant_id = $4
-                WHERE id = $1
-            ";
             let start = Instant::now();
-            sqlx::query(query)
-                .bind(id)
-                .bind(client.push_type)
-                .bind(client.always_raw)
-                .bind(tenant_id)
-                .execute(self)
-                .await?;
+            let mut insert_query = sqlx::QueryBuilder::new(
+                "INSERT INTO public.clients (id, tenant_id, push_type, device_token, always_raw)",
+            );
+            insert_query.push_values(
+                vec![(
+                    id,
+                    tenant_id,
+                    client.push_type,
+                    client.token,
+                    client.always_raw,
+                )],
+                |mut b, client| {
+                    b.push_bind(client.0)
+                        .push_bind(client.1)
+                        .push_bind(client.2)
+                        .push_bind(client.3)
+                        .push_bind(client.4);
+                },
+            );
+            insert_query.build().execute(&mut transaction).await?;
             if let Some(metrics) = metrics {
-                metrics.postgres_query("create_client_update_id", start);
+                metrics.postgres_query("create_client_insert", start);
             }
+        }
+
+        let start = Instant::now();
+        transaction.commit().await?;
+        if let Some(metrics) = metrics {
+            metrics.postgres_query("create_client_commit", start);
         }
 
         Ok(())

--- a/src/stores/client.rs
+++ b/src/stores/client.rs
@@ -105,13 +105,19 @@ impl ClientStore for sqlx::PgPool {
         if existing_client.id == id && existing_client.device_token != client.token {
             let query = "
                 UPDATE public.clients
-                SET device_token = $2
+                SET device_token = $2,
+                    push_type = $3,
+                    always_raw = $4,
+                    tenant_id = $5
                 WHERE id = $1
             ";
             let start = Instant::now();
             sqlx::query(query)
                 .bind(id)
                 .bind(client.token)
+                .bind(client.push_type)
+                .bind(client.always_raw)
+                .bind(tenant_id)
                 .execute(self)
                 .await?;
             if let Some(metrics) = metrics {
@@ -120,13 +126,19 @@ impl ClientStore for sqlx::PgPool {
         } else if existing_client.device_token == client.token && existing_client.id != id {
             let query = "
                 UPDATE public.clients
-                SET id = $2
+                SET id = $2,
+                    push_type = $3,
+                    always_raw = $4,
+                    tenant_id = $5
                 WHERE device_token = $1
             ";
             let start = Instant::now();
             sqlx::query(query)
                 .bind(client.token)
                 .bind(id)
+                .bind(client.push_type)
+                .bind(client.always_raw)
+                .bind(tenant_id)
                 .execute(self)
                 .await?;
             if let Some(metrics) = metrics {


### PR DESCRIPTION
# Description

Currently we are deleting and re-inserting the record, and it turns out the delete operation is quite expensive compared to the insert. Refactoring the queries to only do the operations necessary: insert or update while still locking the record for update.

[Slack conversation](https://walletconnect.slack.com/archives/C03SPNLG39P/p1716246429442999?thread_ts=1716218673.594629&cid=C03SPNLG39P)

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update