### PR TITLE
fix: increasing rate-limiting threshold

### DIFF
--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -77,7 +77,8 @@ describe('Echo Server', () => {
     // Simulate flood of requests and check for rate-limited responses
     it('Rate limiting', async () => {
       const url = `${BASE_URL}/rate_limit_test`
-      const requests_to_send = 100;
+      // x2.5 of the rate limit
+      const requests_to_send = 250;
       const promises = [];
       for (let i = 0; i < requests_to_send; i++) {
         promises.push(

--- a/src/state.rs
+++ b/src/state.rs
@@ -104,7 +104,7 @@ pub fn new_state(
         uptime: std::time::Instant::now(),
         http_client: reqwest::Client::new(),
         provider_cache: Cache::new(100),
-        rate_limit: rate_limit::RateLimiter::new(10, Duration::from_secs(60)),
+        rate_limit: rate_limit::RateLimiter::new(100, Duration::from_secs(60)),
     })
 }
 


### PR DESCRIPTION
# Description

This PR increases the rate-limiting threshold to allow the testing suite to pass.
The threshold is increased to 200 requests per minute in total (100 requests per minute per instance).

## How Has This Been Tested?

Current integration test.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update