### PR TITLE
fix: concurrent client registration errors

### DIFF
--- a/src/stores/client.rs
+++ b/src/stores/client.rs
@@ -59,6 +59,21 @@ impl ClientStore for sqlx::PgPool {
         if let Some(metrics) = metrics {
             metrics.postgres_query("create_client_begin", start);
         }
+        // Lock the records in-case of fast concurrent requests
+        let start = Instant::now();
+        let query = "
+            SELECT
+            pg_advisory_xact_lock(abs(hashtext($1::text))),
+            pg_advisory_xact_lock(abs(hashtext($2::text)))
+        ";
+        sqlx::query(query)
+            .bind(id)
+            .bind(client.token.clone())
+            .execute(&mut transaction)
+            .await?;
+        if let Some(metrics) = metrics {
+            metrics.postgres_query("create_client_pg_advisory_xact_lock", start);
+        }
 
         let query = "
             SELECT *

--- a/src/stores/client.rs
+++ b/src/stores/client.rs
@@ -79,8 +79,11 @@ impl ClientStore for sqlx::PgPool {
                 e => Err(e),
             })?;
         if let Some(metrics) = metrics {
-            metrics.postgres_query("create_client_delete", start);
+            metrics.postgres_query("create_client_select", start);
         }
+
+        #[cfg(feature = "functional_tests")]
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         if let Some(existing_client) = existing_client {
             if existing_client.id == id && existing_client.device_token != client.token {


### PR DESCRIPTION
# Description

Fixes race condition where two INSERTs for the same client ID are made due to clients calling this endpoint in rapid succession.

Alternative would be to return a 409 conflict or assume success when INSERT gives a conflict, but this 1) hides potential errors and 2) doesn't live up to the purest form of idempotency.

## How Has This Been Tested?

New test

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update