### PR TITLE
fix(apns): proper handling of the wrong CA in APNS certificate

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -184,6 +184,9 @@ pub enum Error {
     #[error("Expired APNs certificate")]
     ApnsCertificateExpired,
 
+    #[error("Unknown CA of APNs certificate")]
+    ApnsCertificateUnknownCA,
+
     #[error("client deleted due to invalid device token")]
     ClientDeleted,
 

--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -435,6 +435,23 @@ pub async fn handler_internal(
                     );
                     Err(Error::TenantSuspended)
                 }
+                Error::ApnsCertificateUnknownCA => {
+                    let reason = "Unknown APNs certificate's CA";
+                    state
+                        .tenant_store
+                        .suspend_tenant(&tenant_id, reason)
+                        .await
+                        .map_err(|e| (e, analytics.clone()))?;
+                    increment_counter!(state.metrics, tenant_suspensions);
+                    warn!(
+                        %tenant_id,
+                        client_id = %client_id,
+                        notification_id = %notification.id,
+                        push_type = client.push_type.as_str(),
+                        "tenant has been suspended due to: {reason}"
+                    );
+                    Err(Error::TenantSuspended)
+                }
                 Error::BadFcmApiKey => {
                     state
                         .tenant_store


### PR DESCRIPTION
# Description

This PR adds an additional catching and handling of the `received fatal alert: UnknownCA` APNS client error.
The same action was added to disable the tenant in case of the unknown CA certificate error as for the expired APNS certificate since the certificate can't be used to send the push notification until it is updated.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update