### PR TITLE
fix(clippy): fixing updated clippy dead code warnings

### DIFF
--- a/tests/functional/multitenant/mod.rs
+++ b/tests/functional/multitenant/mod.rs
@@ -13,6 +13,7 @@ mod apns;
 mod fcm;
 #[cfg(feature = "fcmv1_tests")]
 mod fcm_v1;
+#[cfg(feature = "multitenant")]
 mod tenancy;
 
 /// Struct to hold claims for JWT validation


### PR DESCRIPTION
# Description

This PR shadowing code parts behind feature flags, to fix the [new Clippy version warnings](https://github.com/WalletConnect/push-server/actions/runs/9596796319/job/26464439637?pr=343#step:11:838).

## How Has This Been Tested?

* No clippy warnings/errors on `cargo clippy --features=multitenant --tests -- -D warnings`
* No clippy warnings/errors on `cargo clippy --tests -- -D warnings`

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update