### PR TITLE
fix(apns): proper catching of `Unknown CA` error

### DIFF
--- a/src/providers/apns.rs
+++ b/src/providers/apns.rs
@@ -160,9 +160,15 @@ impl PushProvider for ApnsProvider {
                             info!("APNs certificate expired: debug:{dbg}, display: {hyper_error}");
                             Err(Error::ApnsCertificateExpired)
                         }
+                        _ => Err(Error::Apns(e)),
+                    }
+                }
+                a2::Error::ClientError(ref client_error) => {
+                    let dbg = format!("{client_error:?}");
+                    match dbg {
                         dbg if dbg.contains("received fatal alert: UnknownCA") => {
                             info!(
-                                "APNs certificate unknown CA: debug:{dbg}, display: {hyper_error}"
+                                "APNs certificate unknown CA: debug:{dbg}, display: {client_error}"
                             );
                             Err(Error::ApnsCertificateUnknownCA)
                         }


### PR DESCRIPTION
# Description

This PR fixes a proper catching of the `received fatal alert: UnknownCA`.
We [already have matching for this kind of error](https://github.com/WalletConnect/push-server/blob/12794b15566d80d499293c68248fd800b1253188/src/providers/apns.rs#L163), but it was added to the wrong APNS Error.
Instead of being in the `ConnectionError` it should be in the `ClientError` because the error appears in the `ClientError` error type. The full error log:
`Apns(ClientError(Error { kind: SendRequest, source: Some(hyper::Error(Io, Custom { kind: InvalidData, error: "received fatal alert: UnknownCA" })) }))`

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update