### PR TITLE
fix: adding check for the maximum payload size

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -192,6 +192,9 @@ pub enum Error {
 
     #[error("tenant suspended due to invalid configuration")]
     TenantSuspended,
+
+    #[error("Payload too large: {0}")]
+    PayloadTooLarge(String),
 }
 
 impl IntoResponse for Error {
@@ -585,6 +588,12 @@ impl IntoResponse for Error {
                 ResponseError {
                     name: "tenant_suspended".to_string(),
                     message: "Request Accepted, tenant suspended due to invalid configuration".to_string(),
+                },
+            ], vec![]),
+            Error::PayloadTooLarge(message) => crate::handlers::Response::new_failure(StatusCode::BAD_REQUEST, vec![
+                ResponseError {
+                    name: "payload_too_large".to_string(),
+                    message: format!("Payload too large: {}", message),
                 },
             ], vec![]),
             e => {

--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -168,6 +168,18 @@ pub async fn handler_internal(
         )
     })?;
 
+    // Check request body size shouldn't exceed 4Kb (FCM limitations)
+    if serde_json::to_string(&body)
+        .map_err(|e| (Error::InternalSerializationError(e), None))?
+        .len()
+        > 4096
+    {
+        return Err((
+            Error::PayloadTooLarge("Request body size should not exceed 4Kb".to_string()),
+            None,
+        ));
+    };
+
     let cloned_body = body.clone();
     let push_message = if client.always_raw {
         if let Some(body) = body.raw {


### PR DESCRIPTION
# Description

This PR implements a check for the maximum payload size, limiting the size to 4Kb, and throws an appropriate message if exceeding. 
The reason for limiting the body payload size is the FCM support payload up to 4Kb. 
This should fix the following error:
```
FcmV1(UnknownHttpResponse { status: 400, body: Ok("{\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Android message is too big\",\n    \"status\": \"INVALID_ARGUMENT\",\n    \"details\": [\n      {\n        \"@type\": \"type.googleapis.com/google.rpc.BadRequest\"\n      },\n      {\n        \"@type\": \"type.googleapis.com/google.firebase.fcm.v1.FcmError\",\n        \"errorCode\": \"INVALID_ARGUMENT\"\n      }\n    ]\n  }\n}\n") })
```

## How Has This Been Tested?

Not tested, but should be covered by the unit and integration tests.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update