### PR TITLE
fix(apns): proper handling of the invalid provider token response

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -187,6 +187,9 @@ pub enum Error {
     #[error("Unknown CA of APNs certificate")]
     ApnsCertificateUnknownCA,
 
+    #[error("Invalid APNs provider token")]
+    ApnsInvalidProviderToken,
+
     #[error("client deleted due to invalid device token")]
     ClientDeleted,
 

--- a/src/handlers/push_message.rs
+++ b/src/handlers/push_message.rs
@@ -452,6 +452,23 @@ pub async fn handler_internal(
                     );
                     Err(Error::TenantSuspended)
                 }
+                Error::ApnsInvalidProviderToken => {
+                    let reason = "APNs certificate invalid provider token";
+                    state
+                        .tenant_store
+                        .suspend_tenant(&tenant_id, reason)
+                        .await
+                        .map_err(|e| (e, analytics.clone()))?;
+                    increment_counter!(state.metrics, tenant_suspensions);
+                    warn!(
+                        %tenant_id,
+                        client_id = %client_id,
+                        notification_id = %notification.id,
+                        push_type = client.push_type.as_str(),
+                        "tenant has been suspended due to: {reason}"
+                    );
+                    Err(Error::TenantSuspended)
+                }
                 Error::BadFcmApiKey => {
                     state
                         .tenant_store

--- a/src/providers/apns.rs
+++ b/src/providers/apns.rs
@@ -144,6 +144,8 @@ impl PushProvider for ApnsProvider {
                             "The device token is inactive for the specified topic".to_string(),
                         )),
                         ErrorReason::TopicDisallowed => Err(Error::BadApnsCredentials),
+                        // InvalidProviderToken reflecting that APNS certificate must be reissued
+                        ErrorReason::InvalidProviderToken => Err(Error::ApnsInvalidProviderToken),
                         reason => Err(Error::ApnsResponse(reason)),
                     },
                 },


### PR DESCRIPTION
# Description

This PR adds a proper handling of the APNS `InvalidProviderToken` error response. This error type reflects that the APNS certificate should be reissued, switching between business and personal accounts is causing this response.

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update