### PR TITLE
fix(apns): adding proper handling of the too large message payload

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -195,6 +195,9 @@ pub enum Error {
 
     #[error("tenant suspended due to invalid configuration")]
     TenantSuspended,
+
+    #[error("Payload is too large")]
+    PayloadTooLarge,
 }
 
 impl IntoResponse for Error {
@@ -590,6 +593,14 @@ impl IntoResponse for Error {
                     message: "Request Accepted, tenant suspended due to invalid configuration".to_string(),
                 },
             ], vec![]),
+            Error::PayloadTooLarge => crate::handlers::Response::new_failure(
+                StatusCode::BAD_REQUEST,
+                vec![ResponseError {
+                    name: "body".to_string(),
+                    message: "Message payload is too large".to_string(),
+                }],
+                vec![],
+            ),
             e => {
                 warn!("Error does not have response clause, {:?}", e);
 

--- a/src/providers/apns.rs
+++ b/src/providers/apns.rs
@@ -146,6 +146,7 @@ impl PushProvider for ApnsProvider {
                         ErrorReason::TopicDisallowed => Err(Error::BadApnsCredentials),
                         // InvalidProviderToken reflecting that APNS certificate must be reissued
                         ErrorReason::InvalidProviderToken => Err(Error::ApnsInvalidProviderToken),
+                        ErrorReason::PayloadTooLarge => Err(Error::PayloadTooLarge),
                         reason => Err(Error::ApnsResponse(reason)),
                     },
                 },


### PR DESCRIPTION
# Description

This PR adds proper handling of the APNS `PayloadTooLarge` error response by responding `HTTP 400 Bad Request` with the error description instead of `HTTP 500 Internal Server Error`.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update