### PR TITLE
chore: migrate dashboard and data source definition to grafana central

### DIFF
--- a/.github/workflows/ci_terraform.yml
+++ b/.github/workflows/ci_terraform.yml
@@ -34,13 +34,13 @@ jobs:
 
       - name: Init Terraform
         id: tf-init
-        uses: WalletConnect/actions/terraform/init/@1.0.3
+        uses: WalletConnect/actions/terraform/init/@2.5.4
         with:
           environment: staging
 
       - name: Check Terraform Formatting
         id: tf-fmt
-        uses: WalletConnect/actions/terraform/check-fmt/@1.0.3
+        uses: WalletConnect/actions/terraform/check-fmt/@2.5.4
 
   get-version:
     if: github.event_name == 'pull_request'
@@ -109,24 +109,24 @@ jobs:
 
       - name: Get Grafana details
         id: grafana-get-details
-        uses: WalletConnect/actions/aws/grafana/get-details/@1.0.3
+        uses: WalletConnect/actions/aws/grafana/get-details/@2.5.4
 
       - name: Get Grafana key
         id: grafana-get-key
-        uses: WalletConnect/actions/aws/grafana/get-key/@1.0.3
+        uses: WalletConnect/actions/aws/grafana/get-key/@2.5.4
         with:
           key-prefix: ${{ github.event.repository.name }}-staging
           workspace-id: ${{ steps.grafana-get-details.outputs.workspace-id }}
 
       - name: Init Terraform
         id: tf-init
-        uses: WalletConnect/actions/terraform/init/@1.0.3
+        uses: WalletConnect/actions/terraform/init/@2.5.4
         with:
           environment: staging
 
       - name: Run Terraform Plan
         id: tf-plan-staging
-        uses: WalletConnect/actions/terraform/plan/@1.0.3
+        uses: WalletConnect/actions/terraform/plan/@2.5.4
         env:
           TF_VAR_grafana_auth: ${{ steps.grafana-get-key.outputs.key }}
           TF_VAR_grafana_endpoint: ${{ steps.grafana-get-details.outputs.endpoint }}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Delete Grafana key
         id: grafana-delete-key
-        uses: WalletConnect/actions/aws/grafana/delete-key/@1.0.3
+        uses: WalletConnect/actions/aws/grafana/delete-key/@2.5.4
         if: ${{ success() || failure() || cancelled() }} # don't use always() since it creates non-cancellable jobs
         with:
           key-name: ${{ steps.grafana-get-key.outputs.key-name }}

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/alxrem/jsonnet" {
   constraints = "~> 2.3.0"
   hashes = [
     "h1:hhgft+XkSDE5ayFLJEGeyQtH8SDnVIh96XcLISmSP9U=",
+    "h1:nJWe8MlT7oGpKf3j0GL4RJsk02b+8XIjCGtLO58L2Sk=",
     "zh:07479550eb7604605d943cc31fa96b002624be63a1c0c04d3bed350af9ef3543",
     "zh:0b8eba2be9a162f0cc78a5911f760dfefdd78b50ecc785710a98e86f933b53a4",
     "zh:0e320d005a8730a0c1ed65a3bf3bb4bb8c35d4a19005f43e0442cfa3b62622e5",
@@ -26,6 +27,7 @@ provider "registry.terraform.io/alxrem/jsonnet" {
 provider "registry.terraform.io/bwoznicki/assert" {
   version = "0.0.1"
   hashes = [
+    "h1:ONvOG8EeNFSBNNkf28UFViVm8A/9di49gTPnameFVyM=",
     "h1:PqhZ58g8EnSbGN2liQfr+ZlCi/6aDPUiHeugfIoQTbk=",
     "zh:04bcf081b46a1f5a49216355692dec53974d3d653276533eca8ff7c89f17e579",
     "zh:2afe1397d479bc56d34f9f2e567ce87d18e58a1972bdae608d16d05f2987790c",
@@ -46,6 +48,7 @@ provider "registry.terraform.io/grafana/grafana" {
   version     = "2.19.0"
   constraints = "~> 2.0, >= 2.1.0"
   hashes = [
+    "h1:L9A5My0gdANUlMsjuN15MGtoiHmDgxwbtWMolRYkNQE=",
     "h1:Rqn7cIJs9cU+V7Dus2cQwl5HaFhnUAZoZrly3oz9UlM=",
     "zh:0f85e0602ccf119a203f47ee18524a8172457e82b8cbffca7b6b4d7f474639ad",
     "zh:1a626e0d04dedd48cb5b0bdf8a68f428fdf0f7080128928dfaa293a4db78b9b3",
@@ -69,6 +72,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 3.73.0, >= 4.30.0, ~> 4.31"
   hashes = [
     "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "h1:dCRc4GqsyfqHEMjgtlM1EympBcgTmcTkWaJmtd91+KA=",
     "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
     "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
     "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
@@ -92,6 +96,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = ">= 2.2.0, 3.4.3"
   hashes = [
     "h1:saZR+mhthL0OZl4SyHXZraxyaBNVMxiZzks78nWcZ2o=",
+    "h1:xZGZf18JjMS06pFa4NErzANI98qi59SEcBsOcS2P2yQ=",
     "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
     "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
     "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",
@@ -112,6 +117,7 @@ provider "registry.terraform.io/integrations/github" {
   constraints = "5.7.0"
   hashes = [
     "h1:Izwxsn2PaUji/REa6FM5+kN7kHN0pDtVlRfpRsdpJf4=",
+    "h1:it8faA/RfAwPrCktB+AELdhqynSEPzEmWzpgrpYmcXE=",
     "zh:10dbf885c13f1ebb0cebaa81da2febcdf1cd2aa6d96506fbae46e79c066bd38c",
     "zh:1911db0547a5d8bf299747854dec6ba6d11f0122d1706c772ceb0e59c8129e19",
     "zh:1dc4cc6c79a7f07c81e92763eb34a85467e365803636bd88f79bc16a4bc76c7e",

--- a/terraform/inputs.tf
+++ b/terraform/inputs.tf
@@ -1,0 +1,10 @@
+
+data "terraform_remote_state" "monitoring" {
+  backend = "remote"
+  config = {
+    organization = "wallet-connect"
+    workspaces = {
+      name = "monitoring"
+    }
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -192,6 +192,9 @@ module "monitoring" {
   load_balancer_arn       = module.ecs.load_balancer_arn
   environment             = local.environment
   notification_channels   = var.notification_channels
+
+  region              = var.region
+  monitoring_role_arn = data.terraform_remote_state.monitoring.outputs.grafana_workspaces.central.iam_role_arn
 }
 
 data "aws_ecr_repository" "repository" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,6 @@
 locals {
   app_name    = "push"
-  environment = terraform.workspace
+  environment = var.environment
 
   fqdn        = local.environment == "prod" ? var.public_url : "${local.environment}.${var.public_url}"
   backup_fqdn = replace(local.fqdn, ".com", ".org")
@@ -80,7 +80,7 @@ module "database_cluster" {
 
   name           = "${local.environment}-${local.app_name}-database"
   engine         = "aurora-postgresql"
-  engine_version = "13.12"
+  engine_version = "13.18"
   engine_mode    = "provisioned"
   instance_class = "db.serverless"
   instances = {
@@ -114,7 +114,7 @@ module "tenant_database_cluster" {
 
   name           = "${local.environment}-${local.app_name}-tenant-database"
   engine         = "aurora-postgresql"
-  engine_version = "13.12"
+  engine_version = "13.18"
   engine_mode    = "provisioned"
   instance_class = "db.serverless"
   instances = {

--- a/terraform/monitoring/context.tf
+++ b/terraform/monitoring/context.tf
@@ -1,0 +1,7 @@
+module "this" {
+  source  = "app.terraform.io/wallet-connect/label/null"
+  version = "0.3.2"
+
+  region = var.region
+  name   = var.app_name
+}

--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -1,55 +1,54 @@
-local grafana     = import 'grafonnet-lib/grafana.libsonnet';
-local panels      = import 'panels/panels.libsonnet';
+local grafana = import 'grafonnet-lib/grafana.libsonnet';
+local panels = import 'panels/panels.libsonnet';
 
-local dashboard   = grafana.dashboard;
-local row         = grafana.row;
-local annotation  = grafana.annotation;
-local layout      = grafana.layout;
+local dashboard = grafana.dashboard;
+local row = grafana.row;
+local annotation = grafana.annotation;
+local layout = grafana.layout;
 
-local ds    = {
+local ds = {
   prometheus: {
     type: 'prometheus',
-    uid:  std.extVar('prometheus_uid'),
+    uid: std.extVar('prometheus_uid'),
   },
   cloudwatch: {
     type: 'cloudwatch',
-    uid:  std.extVar('cloudwatch_uid'),
+    uid: std.extVar('cloudwatch_uid'),
   },
 };
-local vars  = {
-  namespace:          'Push',
-  environment:        std.extVar('environment'),
-  notifications:      std.parseJson(std.extVar('notifications')),
+local vars = {
+  namespace: 'Push',
+  environment: std.extVar('environment'),
+  notifications: std.parseJson(std.extVar('notifications')),
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-local height    = 8;
-local pos       = grafana.layout.pos(height);
+local height = 8;
+local pos = grafana.layout.pos(height);
 
 ////////////////////////////////////////////////////////////////////////////////
 
 dashboard.new(
-  title         = std.extVar('dashboard_title'),
-  uid           = std.extVar('dashboard_uid'),
-  editable      = true,
-  graphTooltip  = dashboard.graphTooltips.sharedCrosshair,
-  timezone      = dashboard.timezones.utc,
+  title=std.extVar('dashboard_title'),
+  uid=std.extVar('dashboard_uid'),
+  editable=true,
+  graphTooltip=dashboard.graphTooltips.sharedCrosshair,
+  timezone=dashboard.timezones.utc,
 )
 .addAnnotation(
   annotation.new(
-    target = {
-      limit:    100,
+    target={
+      limit: 100,
       matchAny: false,
-      tags:     [],
-      type:     'dashboard',
+      tags: [],
+      type: 'dashboard',
     },
   )
 )
-
 .addPanels(layout.generate_grid([
   //////////////////////////////////////////////////////////////////////////////
   row.new('Application'),
-    panels.app.postgres_query_rate(ds, vars)                        { gridPos: pos._6 },
-    panels.app.postgres_query_latency(ds, vars)                     { gridPos: pos._6 },
+  panels.app.postgres_query_rate(ds, vars) { gridPos: pos._6 },
+  panels.app.postgres_query_latency(ds, vars) { gridPos: pos._6 },
 ]))

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -43,786 +43,786 @@ data "jsonnet_file" "dashboard" {
   }
 }
 
-resource "grafana_dashboard" "at_a_glance" {
+resource "grafana_dashboard" "push_server" {
   overwrite   = true
   message     = "Updated by Terraform"
   config_json = data.jsonnet_file.dashboard.rendered
 }
 
-
-resource "grafana_dashboard" "at_a_glance_old" {
-  overwrite = true
-  message   = "Updated by Terraform"
-  config_json = jsonencode({
-    "annotations" : {
-      "list" : [
-        {
-          "builtIn" : 1,
-          "datasource" : "-- Grafana --",
-          "enable" : true,
-          "hide" : true,
-          "iconColor" : "rgba(0, 211, 255, 1)",
-          "name" : "Annotations & Alerts",
-          "target" : {
-            "limit" : 100,
-            "matchAny" : false,
-            "tags" : [],
-            "type" : "dashboard"
-          },
-          "type" : "dashboard"
-        }
-      ]
-    },
-    "editable" : true,
-    "fiscalYearStartMonth" : 0,
-    "graphTooltip" : 0,
-    "id" : 37,
-    "links" : [],
-    "liveNow" : false,
-    "panels" : [
-      {
-        "datasource" : {
-          "type" : "prometheus",
-          "uid" : grafana_data_source.prometheus.uid
-        },
-        "description" : "",
-        "fieldConfig" : {
-          "defaults" : {
-            "color" : {
-              "mode" : "thresholds"
-            },
-            "mappings" : [],
-            "thresholds" : {
-              "mode" : "absolute",
-              "steps" : [
-                {
-                  "color" : "green",
-                  "value" : null
-                }
-              ]
-            }
-          },
-          "overrides" : []
-        },
-        "gridPos" : {
-          "h" : 8,
-          "w" : 11,
-          "x" : 0,
-          "y" : 0
-        },
-        "id" : 14,
-        "options" : {
-          "colorMode" : "value",
-          "graphMode" : "area",
-          "justifyMode" : "auto",
-          "orientation" : "auto",
-          "reduceOptions" : {
-            "calcs" : [
-              "lastNotNull"
-            ],
-            "fields" : "",
-            "values" : false
-          },
-          "text" : {},
-          "textMode" : "auto"
-        },
-        "pluginVersion" : "8.4.7",
-        "targets" : [
-          {
-            "datasource" : {
-              "type" : "prometheus",
-              "uid" : grafana_data_source.prometheus.uid
-            },
-            "expr" : "sum(rate(received_notifications_total{}[1h]))",
-            "legendFormat" : "__auto",
-            "refId" : "Received"
-          },
-          {
-            "datasource" : {
-              "type" : "prometheus",
-              "uid" : grafana_data_source.prometheus.uid
-            },
-            "editorMode" : "code",
-            "expr" : "sum(increase(sent_apns_notifications_total{}[1h]))",
-            "hide" : false,
-            "legendFormat" : "__auto",
-            "range" : true,
-            "refId" : "SentAPNS"
-          },
-          {
-            "datasource" : {
-              "type" : "prometheus",
-              "uid" : grafana_data_source.prometheus.uid
-            },
-            "editorMode" : "code",
-            "expr" : "sum(increase(sent_fcm_notifications_total{}[1h]))",
-            "hide" : false,
-            "legendFormat" : "__auto",
-            "range" : true,
-            "refId" : "SentFCM"
-          }
-        ],
-        "title" : "Notifications per Hour",
-        "type" : "stat"
-      },
-      {
-        "gridPos" : {
-          "h" : 1,
-          "w" : 24,
-          "x" : 0,
-          "y" : 8
-        },
-        "id" : 8,
-        "title" : "Graphs",
-        "type" : "row"
-      },
-      {
-        "datasource" : {
-          "type" : "prometheus",
-          "uid" : grafana_data_source.prometheus.uid
-        },
-        "fieldConfig" : {
-          "defaults" : {
-            "color" : {
-              "mode" : "palette-classic"
-            },
-            "custom" : {
-              "axisLabel" : "Notifications",
-              "axisPlacement" : "auto",
-              "barAlignment" : 0,
-              "drawStyle" : "line",
-              "fillOpacity" : 0,
-              "gradientMode" : "none",
-              "hideFrom" : {
-                "legend" : false,
-                "tooltip" : false,
-                "viz" : false
-              },
-              "lineInterpolation" : "linear",
-              "lineWidth" : 1,
-              "pointSize" : 5,
-              "scaleDistribution" : {
-                "type" : "linear"
-              },
-              "showPoints" : "auto",
-              "spanNulls" : false,
-              "stacking" : {
-                "group" : "A",
-                "mode" : "none"
-              },
-              "thresholdsStyle" : {
-                "mode" : "off"
-              }
-            },
-            "mappings" : [],
-            "thresholds" : {
-              "mode" : "absolute",
-              "steps" : [
-                {
-                  "color" : "green",
-                  "value" : null
-                }
-              ]
-            },
-            "unit" : "none"
-          },
-          "overrides" : [
-            {
-              "__systemRef" : "hideSeriesFrom",
-              "matcher" : {
-                "id" : "byNames",
-                "options" : {
-                  "mode" : "exclude",
-                  "names" : [
-                    "sum(received_notifications{})"
-                  ],
-                  "prefix" : "All except:",
-                  "readOnly" : true
-                }
-              },
-              "properties" : [
-                {
-                  "id" : "custom.hideFrom",
-                  "value" : {
-                    "legend" : false,
-                    "tooltip" : false,
-                    "viz" : true
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos" : {
-          "h" : 8,
-          "w" : 11,
-          "x" : 0,
-          "y" : 9
-        },
-        "id" : 10,
-        "options" : {
-          "legend" : {
-            "calcs" : [],
-            "displayMode" : "list",
-            "placement" : "bottom"
-          },
-          "tooltip" : {
-            "mode" : "single",
-            "sort" : "none"
-          }
-        },
-        "targets" : [
-          {
-            "datasource" : {
-              "type" : "prometheus",
-              "uid" : grafana_data_source.prometheus.uid
-            },
-            "exemplar" : true,
-            "expr" : "sum(increase(received_notifications_total{}[1h]))",
-            "format" : "time_series",
-            "interval" : "",
-            "legendFormat" : "",
-            "refId" : "Notifications"
-          }
-        ],
-        "title" : "Received Notifications",
-        "type" : "timeseries"
-      },
-      {
-        "datasource" : {
-          "type" : "prometheus",
-          "uid" : grafana_data_source.prometheus.uid
-        },
-        "fieldConfig" : {
-          "defaults" : {
-            "color" : {
-              "mode" : "palette-classic"
-            },
-            "custom" : {
-              "axisLabel" : "Clients",
-              "axisPlacement" : "auto",
-              "barAlignment" : 0,
-              "drawStyle" : "line",
-              "fillOpacity" : 0,
-              "gradientMode" : "none",
-              "hideFrom" : {
-                "legend" : false,
-                "tooltip" : false,
-                "viz" : false
-              },
-              "lineInterpolation" : "linear",
-              "lineWidth" : 1,
-              "pointSize" : 5,
-              "scaleDistribution" : {
-                "type" : "linear"
-              },
-              "showPoints" : "auto",
-              "spanNulls" : false,
-              "stacking" : {
-                "group" : "A",
-                "mode" : "none"
-              },
-              "thresholdsStyle" : {
-                "mode" : "off"
-              }
-            },
-            "mappings" : [],
-            "thresholds" : {
-              "mode" : "absolute",
-              "steps" : [
-                {
-                  "color" : "green",
-                  "value" : null
-                },
-                {
-                  "color" : "red",
-                  "value" : 80
-                }
-              ]
-            }
-          },
-          "overrides" : []
-        },
-        "gridPos" : {
-          "h" : 8,
-          "w" : 10,
-          "x" : 11,
-          "y" : 9
-        },
-        "id" : 12,
-        "options" : {
-          "legend" : {
-            "calcs" : [],
-            "displayMode" : "list",
-            "placement" : "bottom"
-          },
-          "tooltip" : {
-            "mode" : "single",
-            "sort" : "none"
-          }
-        },
-        "targets" : [
-          {
-            "datasource" : {
-              "type" : "prometheus",
-              "uid" : grafana_data_source.prometheus.uid
-            },
-            "exemplar" : true,
-            "expr" : "sum(rate(registered_clients_total{}[$__rate_interval]))",
-            "interval" : "",
-            "legendFormat" : "",
-            "refId" : "Clients"
-          }
-        ],
-        "title" : "Client registration rate",
-        "type" : "timeseries"
-      },
-      {
-        "collapsed" : false,
-        "gridPos" : {
-          "h" : 1,
-          "w" : 24,
-          "x" : 0,
-          "y" : 17
-        },
-        "id" : 6,
-        "panels" : [],
-        "title" : "AWS Load Balancer",
-        "type" : "row"
-      },
-      {
-        "datasource" : {
-          "type" : "cloudwatch",
-          "uid" : grafana_data_source.cloudwatch.uid
-        },
-        "fieldConfig" : {
-          "defaults" : {
-            "color" : {
-              "mode" : "palette-classic"
-            },
-            "custom" : {
-              "axisLabel" : "",
-              "axisPlacement" : "auto",
-              "barAlignment" : 0,
-              "drawStyle" : "line",
-              "fillOpacity" : 0,
-              "gradientMode" : "none",
-              "hideFrom" : {
-                "legend" : false,
-                "tooltip" : false,
-                "viz" : false
-              },
-              "lineInterpolation" : "linear",
-              "lineWidth" : 1,
-              "pointSize" : 5,
-              "scaleDistribution" : {
-                "type" : "linear"
-              },
-              "showPoints" : "auto",
-              "spanNulls" : false,
-              "stacking" : {
-                "group" : "A",
-                "mode" : "none"
-              },
-              "thresholdsStyle" : {
-                "mode" : "off"
-              }
-            },
-            "mappings" : [],
-            "thresholds" : {
-              "mode" : "absolute",
-              "steps" : [
-                {
-                  "color" : "green",
-                  "value" : null
-                },
-                {
-                  "color" : "red",
-                  "value" : 80
-                }
-              ]
-            }
-          },
-          "overrides" : []
-        },
-        "gridPos" : {
-          "h" : 9,
-          "w" : 7,
-          "x" : 0,
-          "y" : 18
-        },
-        "id" : 2,
-        "options" : {
-          "legend" : {
-            "calcs" : [],
-            "displayMode" : "list",
-            "placement" : "bottom"
-          },
-          "tooltip" : {
-            "mode" : "single",
-            "sort" : "none"
-          }
-        },
-        "targets" : [
-          {
-            "alias" : "",
-            "datasource" : {
-              "type" : "cloudwatch",
-              "uid" : grafana_data_source.cloudwatch.uid
-            },
-            "dimensions" : {
-              "LoadBalancer" : local.load_balancer
-            },
-            "expression" : "",
-            "id" : "",
-            "matchExact" : true,
-            "metricEditorMode" : 0,
-            "metricName" : "RequestCount",
-            "metricQueryType" : 0,
-            "namespace" : "AWS/ApplicationELB",
-            "period" : "",
-            "queryMode" : "Metrics",
-            "refId" : "A",
-            "region" : "default",
-            "sqlExpression" : "",
-            "statistic" : "Sum"
-          }
-        ],
-        "title" : "Requests",
-        "type" : "timeseries"
-      },
-      {
-        "alert" : {
-          "alertRuleTags" : {},
-          "conditions" : [
-            {
-              "evaluator" : {
-                "params" : [
-                  15
-                ],
-                "type" : "gt"
-              },
-              "operator" : {
-                "type" : "and"
-              },
-              "query" : {
-                "params" : [
-                  "A",
-                  "5m",
-                  "now"
-                ]
-              },
-              "reducer" : {
-                "params" : [],
-                "type" : "sum"
-              },
-              "type" : "query"
-            },
-            {
-              "evaluator" : {
-                "params" : [
-                  15
-                ],
-                "type" : "gt"
-              },
-              "operator" : {
-                "type" : "or"
-              },
-              "query" : {
-                "params" : [
-                  "B",
-                  "5m",
-                  "now"
-                ]
-              },
-              "reducer" : {
-                "params" : [],
-                "type" : "sum"
-              },
-              "type" : "query"
-            }
-          ],
-          "executionErrorState" : "alerting",
-          "frequency" : "1m",
-          "for" : "",
-          "handler" : 1,
-          "name" : "${var.environment} Echo Server 5XX alert",
-          "noDataState" : "no_data",
-          "message" : "Echo server - Prod - 5XX error",
-          "notifications" : var.notification_channels
-        },
-        "datasource" : {
-          "type" : "cloudwatch",
-          "uid" : grafana_data_source.cloudwatch.uid
-        },
-        "fieldConfig" : {
-          "defaults" : {
-            "color" : {
-              "mode" : "palette-classic"
-            },
-            "custom" : {
-              "axisLabel" : "",
-              "axisPlacement" : "auto",
-              "barAlignment" : 0,
-              "drawStyle" : "line",
-              "fillOpacity" : 0,
-              "gradientMode" : "none",
-              "hideFrom" : {
-                "legend" : false,
-                "tooltip" : false,
-                "viz" : false,
-                "mode" : "dashed",
-              },
-              "lineInterpolation" : "linear",
-              "lineWidth" : 1,
-              "pointSize" : 5,
-              "scaleDistribution" : {
-                "type" : "linear"
-              },
-              "showPoints" : "auto",
-              "spanNulls" : false,
-              "stacking" : {
-                "group" : "A",
-                "mode" : "none"
-              },
-              "thresholdsStyle" : {
-                "mode" : "off"
-              }
-            },
-            "mappings" : [],
-            "thresholds" : {
-              "mode" : "absolute",
-              "steps" : [
-                {
-                  "color" : "green",
-                  "value" : null
-                },
-                {
-                  "color" : "red",
-                  "value" : 80
-                }
-              ]
-            }
-          },
-          "overrides" : []
-        },
-        "gridPos" : {
-          "h" : 9,
-          "w" : 7,
-          "x" : 7,
-          "y" : 18
-        },
-        "id" : 3,
-        "options" : {
-          "legend" : {
-            "calcs" : [],
-            "displayMode" : "list",
-            "placement" : "bottom"
-          },
-          "tooltip" : {
-            "mode" : "single",
-            "sort" : "none"
-          }
-        },
-        "targets" : [
-          {
-            "alias" : "",
-            "datasource" : {
-              "type" : "cloudwatch",
-              "uid" : grafana_data_source.cloudwatch.uid
-            },
-            "dimensions" : {
-              "LoadBalancer" : local.load_balancer
-            },
-            "expression" : "",
-            "id" : "",
-            "matchExact" : true,
-            "metricEditorMode" : 0,
-            "metricName" : "HTTPCode_ELB_5XX_Count",
-            "metricQueryType" : 0,
-            "namespace" : "AWS/ApplicationELB",
-            "period" : "",
-            "queryMode" : "Metrics",
-            "refId" : "A",
-            "region" : "default",
-            "sqlExpression" : "",
-            "statistic" : "Sum"
-          },
-          {
-            "alias" : "",
-            "datasource" : {
-              "type" : "cloudwatch",
-              "uid" : grafana_data_source.cloudwatch.uid
-            },
-            "dimensions" : {
-              "LoadBalancer" : local.load_balancer
-            },
-            "expression" : "",
-            "id" : "",
-            "matchExact" : true,
-            "metricEditorMode" : 0,
-            "metricName" : "HTTPCode_Target_5XX_Count",
-            "metricQueryType" : 0,
-            "namespace" : "AWS/ApplicationELB",
-            "period" : "",
-            "queryMode" : "Metrics",
-            "refId" : "B",
-            "region" : "default",
-            "sqlExpression" : "",
-            "statistic" : "Sum"
-          }
-        ],
-        "thresholds" : [
-          {
-            "colorMode" : "critical",
-            "op" : "gt",
-            "value" : 1,
-            "visible" : true
-          }
-        ],
-        "title" : "5XX",
-        "type" : "timeseries"
-      },
-      {
-        "datasource" : {
-          "type" : "cloudwatch",
-          "uid" : grafana_data_source.cloudwatch.uid
-        },
-        "fieldConfig" : {
-          "defaults" : {
-            "color" : {
-              "mode" : "palette-classic"
-            },
-            "custom" : {
-              "axisLabel" : "",
-              "axisPlacement" : "auto",
-              "barAlignment" : 0,
-              "drawStyle" : "line",
-              "fillOpacity" : 0,
-              "gradientMode" : "none",
-              "hideFrom" : {
-                "legend" : false,
-                "tooltip" : false,
-                "viz" : false
-              },
-              "lineInterpolation" : "linear",
-              "lineWidth" : 1,
-              "pointSize" : 5,
-              "scaleDistribution" : {
-                "type" : "linear"
-              },
-              "showPoints" : "auto",
-              "spanNulls" : false,
-              "stacking" : {
-                "group" : "A",
-                "mode" : "none"
-              },
-              "thresholdsStyle" : {
-                "mode" : "off"
-              }
-            },
-            "mappings" : [],
-            "thresholds" : {
-              "mode" : "absolute",
-              "steps" : [
-                {
-                  "color" : "green",
-                  "value" : null
-                },
-                {
-                  "color" : "red",
-                  "value" : 80
-                }
-              ]
-            }
-          },
-          "overrides" : []
-        },
-        "gridPos" : {
-          "h" : 9,
-          "w" : 7,
-          "x" : 14,
-          "y" : 18
-        },
-        "id" : 4,
-        "options" : {
-          "legend" : {
-            "calcs" : [],
-            "displayMode" : "list",
-            "placement" : "bottom"
-          },
-          "tooltip" : {
-            "mode" : "single",
-            "sort" : "none"
-          }
-        },
-        "targets" : [
-          {
-            "alias" : "",
-            "datasource" : {
-              "type" : "cloudwatch",
-              "uid" : grafana_data_source.cloudwatch.uid
-            },
-            "dimensions" : {
-              "LoadBalancer" : local.load_balancer
-            },
-            "expression" : "",
-            "id" : "",
-            "matchExact" : true,
-            "metricEditorMode" : 0,
-            "metricName" : "HTTPCode_ELB_4XX_Count",
-            "metricQueryType" : 0,
-            "namespace" : "AWS/ApplicationELB",
-            "period" : "",
-            "queryMode" : "Metrics",
-            "refId" : "A",
-            "region" : "default",
-            "sqlExpression" : "",
-            "statistic" : "Sum"
-          },
-          {
-            "alias" : "",
-            "datasource" : {
-              "type" : "cloudwatch",
-              "uid" : grafana_data_source.cloudwatch.uid
-            },
-            "dimensions" : {
-              "LoadBalancer" : local.load_balancer
-            },
-            "expression" : "",
-            "id" : "",
-            "matchExact" : true,
-            "metricEditorMode" : 0,
-            "metricName" : "HTTPCode_Target_4XX_Count",
-            "metricQueryType" : 0,
-            "namespace" : "AWS/ApplicationELB",
-            "period" : "",
-            "queryMode" : "Metrics",
-            "refId" : "B",
-            "region" : "default",
-            "sqlExpression" : "",
-            "statistic" : "Sum"
-          }
-        ],
-        "title" : "4XX",
-        "type" : "timeseries"
-      }
-    ],
-    "schemaVersion" : 35,
-    "style" : "dark",
-    "tags" : [],
-    "templating" : {
-      "list" : []
-    },
-    "time" : {
-      "from" : "now-6h",
-      "to" : "now"
-    },
-    "timepicker" : {},
-    "timezone" : "",
-    "title" : "${var.app_name} - old",
-    "uid" : "${var.app_name}-old",
-    "version" : 13,
-    "weekStart" : ""
-  })
-}
+# TODO: deprecate this resource
+# resource "grafana_dashboard" "at_a_glance_old" {
+#   overwrite = true
+#   message   = "Updated by Terraform"
+#   config_json = jsonencode({
+#     "annotations" : {
+#       "list" : [
+#         {
+#           "builtIn" : 1,
+#           "datasource" : "-- Grafana --",
+#           "enable" : true,
+#           "hide" : true,
+#           "iconColor" : "rgba(0, 211, 255, 1)",
+#           "name" : "Annotations & Alerts",
+#           "target" : {
+#             "limit" : 100,
+#             "matchAny" : false,
+#             "tags" : [],
+#             "type" : "dashboard"
+#           },
+#           "type" : "dashboard"
+#         }
+#       ]
+#     },
+#     "editable" : true,
+#     "fiscalYearStartMonth" : 0,
+#     "graphTooltip" : 0,
+#     "id" : 37,
+#     "links" : [],
+#     "liveNow" : false,
+#     "panels" : [
+#       {
+#         "datasource" : {
+#           "type" : "prometheus",
+#           "uid" : grafana_data_source.prometheus.uid
+#         },
+#         "description" : "",
+#         "fieldConfig" : {
+#           "defaults" : {
+#             "color" : {
+#               "mode" : "thresholds"
+#             },
+#             "mappings" : [],
+#             "thresholds" : {
+#               "mode" : "absolute",
+#               "steps" : [
+#                 {
+#                   "color" : "green",
+#                   "value" : null
+#                 }
+#               ]
+#             }
+#           },
+#           "overrides" : []
+#         },
+#         "gridPos" : {
+#           "h" : 8,
+#           "w" : 11,
+#           "x" : 0,
+#           "y" : 0
+#         },
+#         "id" : 14,
+#         "options" : {
+#           "colorMode" : "value",
+#           "graphMode" : "area",
+#           "justifyMode" : "auto",
+#           "orientation" : "auto",
+#           "reduceOptions" : {
+#             "calcs" : [
+#               "lastNotNull"
+#             ],
+#             "fields" : "",
+#             "values" : false
+#           },
+#           "text" : {},
+#           "textMode" : "auto"
+#         },
+#         "pluginVersion" : "8.4.7",
+#         "targets" : [
+#           {
+#             "datasource" : {
+#               "type" : "prometheus",
+#               "uid" : grafana_data_source.prometheus.uid
+#             },
+#             "expr" : "sum(rate(received_notifications_total{}[1h]))",
+#             "legendFormat" : "__auto",
+#             "refId" : "Received"
+#           },
+#           {
+#             "datasource" : {
+#               "type" : "prometheus",
+#               "uid" : grafana_data_source.prometheus.uid
+#             },
+#             "editorMode" : "code",
+#             "expr" : "sum(increase(sent_apns_notifications_total{}[1h]))",
+#             "hide" : false,
+#             "legendFormat" : "__auto",
+#             "range" : true,
+#             "refId" : "SentAPNS"
+#           },
+#           {
+#             "datasource" : {
+#               "type" : "prometheus",
+#               "uid" : grafana_data_source.prometheus.uid
+#             },
+#             "editorMode" : "code",
+#             "expr" : "sum(increase(sent_fcm_notifications_total{}[1h]))",
+#             "hide" : false,
+#             "legendFormat" : "__auto",
+#             "range" : true,
+#             "refId" : "SentFCM"
+#           }
+#         ],
+#         "title" : "Notifications per Hour",
+#         "type" : "stat"
+#       },
+#       {
+#         "gridPos" : {
+#           "h" : 1,
+#           "w" : 24,
+#           "x" : 0,
+#           "y" : 8
+#         },
+#         "id" : 8,
+#         "title" : "Graphs",
+#         "type" : "row"
+#       },
+#       {
+#         "datasource" : {
+#           "type" : "prometheus",
+#           "uid" : grafana_data_source.prometheus.uid
+#         },
+#         "fieldConfig" : {
+#           "defaults" : {
+#             "color" : {
+#               "mode" : "palette-classic"
+#             },
+#             "custom" : {
+#               "axisLabel" : "Notifications",
+#               "axisPlacement" : "auto",
+#               "barAlignment" : 0,
+#               "drawStyle" : "line",
+#               "fillOpacity" : 0,
+#               "gradientMode" : "none",
+#               "hideFrom" : {
+#                 "legend" : false,
+#                 "tooltip" : false,
+#                 "viz" : false
+#               },
+#               "lineInterpolation" : "linear",
+#               "lineWidth" : 1,
+#               "pointSize" : 5,
+#               "scaleDistribution" : {
+#                 "type" : "linear"
+#               },
+#               "showPoints" : "auto",
+#               "spanNulls" : false,
+#               "stacking" : {
+#                 "group" : "A",
+#                 "mode" : "none"
+#               },
+#               "thresholdsStyle" : {
+#                 "mode" : "off"
+#               }
+#             },
+#             "mappings" : [],
+#             "thresholds" : {
+#               "mode" : "absolute",
+#               "steps" : [
+#                 {
+#                   "color" : "green",
+#                   "value" : null
+#                 }
+#               ]
+#             },
+#             "unit" : "none"
+#           },
+#           "overrides" : [
+#             {
+#               "__systemRef" : "hideSeriesFrom",
+#               "matcher" : {
+#                 "id" : "byNames",
+#                 "options" : {
+#                   "mode" : "exclude",
+#                   "names" : [
+#                     "sum(received_notifications{})"
+#                   ],
+#                   "prefix" : "All except:",
+#                   "readOnly" : true
+#                 }
+#               },
+#               "properties" : [
+#                 {
+#                   "id" : "custom.hideFrom",
+#                   "value" : {
+#                     "legend" : false,
+#                     "tooltip" : false,
+#                     "viz" : true
+#                   }
+#                 }
+#               ]
+#             }
+#           ]
+#         },
+#         "gridPos" : {
+#           "h" : 8,
+#           "w" : 11,
+#           "x" : 0,
+#           "y" : 9
+#         },
+#         "id" : 10,
+#         "options" : {
+#           "legend" : {
+#             "calcs" : [],
+#             "displayMode" : "list",
+#             "placement" : "bottom"
+#           },
+#           "tooltip" : {
+#             "mode" : "single",
+#             "sort" : "none"
+#           }
+#         },
+#         "targets" : [
+#           {
+#             "datasource" : {
+#               "type" : "prometheus",
+#               "uid" : grafana_data_source.prometheus.uid
+#             },
+#             "exemplar" : true,
+#             "expr" : "sum(increase(received_notifications_total{}[1h]))",
+#             "format" : "time_series",
+#             "interval" : "",
+#             "legendFormat" : "",
+#             "refId" : "Notifications"
+#           }
+#         ],
+#         "title" : "Received Notifications",
+#         "type" : "timeseries"
+#       },
+#       {
+#         "datasource" : {
+#           "type" : "prometheus",
+#           "uid" : grafana_data_source.prometheus.uid
+#         },
+#         "fieldConfig" : {
+#           "defaults" : {
+#             "color" : {
+#               "mode" : "palette-classic"
+#             },
+#             "custom" : {
+#               "axisLabel" : "Clients",
+#               "axisPlacement" : "auto",
+#               "barAlignment" : 0,
+#               "drawStyle" : "line",
+#               "fillOpacity" : 0,
+#               "gradientMode" : "none",
+#               "hideFrom" : {
+#                 "legend" : false,
+#                 "tooltip" : false,
+#                 "viz" : false
+#               },
+#               "lineInterpolation" : "linear",
+#               "lineWidth" : 1,
+#               "pointSize" : 5,
+#               "scaleDistribution" : {
+#                 "type" : "linear"
+#               },
+#               "showPoints" : "auto",
+#               "spanNulls" : false,
+#               "stacking" : {
+#                 "group" : "A",
+#                 "mode" : "none"
+#               },
+#               "thresholdsStyle" : {
+#                 "mode" : "off"
+#               }
+#             },
+#             "mappings" : [],
+#             "thresholds" : {
+#               "mode" : "absolute",
+#               "steps" : [
+#                 {
+#                   "color" : "green",
+#                   "value" : null
+#                 },
+#                 {
+#                   "color" : "red",
+#                   "value" : 80
+#                 }
+#               ]
+#             }
+#           },
+#           "overrides" : []
+#         },
+#         "gridPos" : {
+#           "h" : 8,
+#           "w" : 10,
+#           "x" : 11,
+#           "y" : 9
+#         },
+#         "id" : 12,
+#         "options" : {
+#           "legend" : {
+#             "calcs" : [],
+#             "displayMode" : "list",
+#             "placement" : "bottom"
+#           },
+#           "tooltip" : {
+#             "mode" : "single",
+#             "sort" : "none"
+#           }
+#         },
+#         "targets" : [
+#           {
+#             "datasource" : {
+#               "type" : "prometheus",
+#               "uid" : grafana_data_source.prometheus.uid
+#             },
+#             "exemplar" : true,
+#             "expr" : "sum(rate(registered_clients_total{}[$__rate_interval]))",
+#             "interval" : "",
+#             "legendFormat" : "",
+#             "refId" : "Clients"
+#           }
+#         ],
+#         "title" : "Client registration rate",
+#         "type" : "timeseries"
+#       },
+#       {
+#         "collapsed" : false,
+#         "gridPos" : {
+#           "h" : 1,
+#           "w" : 24,
+#           "x" : 0,
+#           "y" : 17
+#         },
+#         "id" : 6,
+#         "panels" : [],
+#         "title" : "AWS Load Balancer",
+#         "type" : "row"
+#       },
+#       {
+#         "datasource" : {
+#           "type" : "cloudwatch",
+#           "uid" : grafana_data_source.cloudwatch.uid
+#         },
+#         "fieldConfig" : {
+#           "defaults" : {
+#             "color" : {
+#               "mode" : "palette-classic"
+#             },
+#             "custom" : {
+#               "axisLabel" : "",
+#               "axisPlacement" : "auto",
+#               "barAlignment" : 0,
+#               "drawStyle" : "line",
+#               "fillOpacity" : 0,
+#               "gradientMode" : "none",
+#               "hideFrom" : {
+#                 "legend" : false,
+#                 "tooltip" : false,
+#                 "viz" : false
+#               },
+#               "lineInterpolation" : "linear",
+#               "lineWidth" : 1,
+#               "pointSize" : 5,
+#               "scaleDistribution" : {
+#                 "type" : "linear"
+#               },
+#               "showPoints" : "auto",
+#               "spanNulls" : false,
+#               "stacking" : {
+#                 "group" : "A",
+#                 "mode" : "none"
+#               },
+#               "thresholdsStyle" : {
+#                 "mode" : "off"
+#               }
+#             },
+#             "mappings" : [],
+#             "thresholds" : {
+#               "mode" : "absolute",
+#               "steps" : [
+#                 {
+#                   "color" : "green",
+#                   "value" : null
+#                 },
+#                 {
+#                   "color" : "red",
+#                   "value" : 80
+#                 }
+#               ]
+#             }
+#           },
+#           "overrides" : []
+#         },
+#         "gridPos" : {
+#           "h" : 9,
+#           "w" : 7,
+#           "x" : 0,
+#           "y" : 18
+#         },
+#         "id" : 2,
+#         "options" : {
+#           "legend" : {
+#             "calcs" : [],
+#             "displayMode" : "list",
+#             "placement" : "bottom"
+#           },
+#           "tooltip" : {
+#             "mode" : "single",
+#             "sort" : "none"
+#           }
+#         },
+#         "targets" : [
+#           {
+#             "alias" : "",
+#             "datasource" : {
+#               "type" : "cloudwatch",
+#               "uid" : grafana_data_source.cloudwatch.uid
+#             },
+#             "dimensions" : {
+#               "LoadBalancer" : local.load_balancer
+#             },
+#             "expression" : "",
+#             "id" : "",
+#             "matchExact" : true,
+#             "metricEditorMode" : 0,
+#             "metricName" : "RequestCount",
+#             "metricQueryType" : 0,
+#             "namespace" : "AWS/ApplicationELB",
+#             "period" : "",
+#             "queryMode" : "Metrics",
+#             "refId" : "A",
+#             "region" : "default",
+#             "sqlExpression" : "",
+#             "statistic" : "Sum"
+#           }
+#         ],
+#         "title" : "Requests",
+#         "type" : "timeseries"
+#       },
+#       {
+#         "alert" : {
+#           "alertRuleTags" : {},
+#           "conditions" : [
+#             {
+#               "evaluator" : {
+#                 "params" : [
+#                   15
+#                 ],
+#                 "type" : "gt"
+#               },
+#               "operator" : {
+#                 "type" : "and"
+#               },
+#               "query" : {
+#                 "params" : [
+#                   "A",
+#                   "5m",
+#                   "now"
+#                 ]
+#               },
+#               "reducer" : {
+#                 "params" : [],
+#                 "type" : "sum"
+#               },
+#               "type" : "query"
+#             },
+#             {
+#               "evaluator" : {
+#                 "params" : [
+#                   15
+#                 ],
+#                 "type" : "gt"
+#               },
+#               "operator" : {
+#                 "type" : "or"
+#               },
+#               "query" : {
+#                 "params" : [
+#                   "B",
+#                   "5m",
+#                   "now"
+#                 ]
+#               },
+#               "reducer" : {
+#                 "params" : [],
+#                 "type" : "sum"
+#               },
+#               "type" : "query"
+#             }
+#           ],
+#           "executionErrorState" : "alerting",
+#           "frequency" : "1m",
+#           "for" : "",
+#           "handler" : 1,
+#           "name" : "${var.environment} Echo Server 5XX alert",
+#           "noDataState" : "no_data",
+#           "message" : "Echo server - Prod - 5XX error",
+#           "notifications" : var.notification_channels
+#         },
+#         "datasource" : {
+#           "type" : "cloudwatch",
+#           "uid" : grafana_data_source.cloudwatch.uid
+#         },
+#         "fieldConfig" : {
+#           "defaults" : {
+#             "color" : {
+#               "mode" : "palette-classic"
+#             },
+#             "custom" : {
+#               "axisLabel" : "",
+#               "axisPlacement" : "auto",
+#               "barAlignment" : 0,
+#               "drawStyle" : "line",
+#               "fillOpacity" : 0,
+#               "gradientMode" : "none",
+#               "hideFrom" : {
+#                 "legend" : false,
+#                 "tooltip" : false,
+#                 "viz" : false,
+#                 "mode" : "dashed",
+#               },
+#               "lineInterpolation" : "linear",
+#               "lineWidth" : 1,
+#               "pointSize" : 5,
+#               "scaleDistribution" : {
+#                 "type" : "linear"
+#               },
+#               "showPoints" : "auto",
+#               "spanNulls" : false,
+#               "stacking" : {
+#                 "group" : "A",
+#                 "mode" : "none"
+#               },
+#               "thresholdsStyle" : {
+#                 "mode" : "off"
+#               }
+#             },
+#             "mappings" : [],
+#             "thresholds" : {
+#               "mode" : "absolute",
+#               "steps" : [
+#                 {
+#                   "color" : "green",
+#                   "value" : null
+#                 },
+#                 {
+#                   "color" : "red",
+#                   "value" : 80
+#                 }
+#               ]
+#             }
+#           },
+#           "overrides" : []
+#         },
+#         "gridPos" : {
+#           "h" : 9,
+#           "w" : 7,
+#           "x" : 7,
+#           "y" : 18
+#         },
+#         "id" : 3,
+#         "options" : {
+#           "legend" : {
+#             "calcs" : [],
+#             "displayMode" : "list",
+#             "placement" : "bottom"
+#           },
+#           "tooltip" : {
+#             "mode" : "single",
+#             "sort" : "none"
+#           }
+#         },
+#         "targets" : [
+#           {
+#             "alias" : "",
+#             "datasource" : {
+#               "type" : "cloudwatch",
+#               "uid" : grafana_data_source.cloudwatch.uid
+#             },
+#             "dimensions" : {
+#               "LoadBalancer" : local.load_balancer
+#             },
+#             "expression" : "",
+#             "id" : "",
+#             "matchExact" : true,
+#             "metricEditorMode" : 0,
+#             "metricName" : "HTTPCode_ELB_5XX_Count",
+#             "metricQueryType" : 0,
+#             "namespace" : "AWS/ApplicationELB",
+#             "period" : "",
+#             "queryMode" : "Metrics",
+#             "refId" : "A",
+#             "region" : "default",
+#             "sqlExpression" : "",
+#             "statistic" : "Sum"
+#           },
+#           {
+#             "alias" : "",
+#             "datasource" : {
+#               "type" : "cloudwatch",
+#               "uid" : grafana_data_source.cloudwatch.uid
+#             },
+#             "dimensions" : {
+#               "LoadBalancer" : local.load_balancer
+#             },
+#             "expression" : "",
+#             "id" : "",
+#             "matchExact" : true,
+#             "metricEditorMode" : 0,
+#             "metricName" : "HTTPCode_Target_5XX_Count",
+#             "metricQueryType" : 0,
+#             "namespace" : "AWS/ApplicationELB",
+#             "period" : "",
+#             "queryMode" : "Metrics",
+#             "refId" : "B",
+#             "region" : "default",
+#             "sqlExpression" : "",
+#             "statistic" : "Sum"
+#           }
+#         ],
+#         "thresholds" : [
+#           {
+#             "colorMode" : "critical",
+#             "op" : "gt",
+#             "value" : 1,
+#             "visible" : true
+#           }
+#         ],
+#         "title" : "5XX",
+#         "type" : "timeseries"
+#       },
+#       {
+#         "datasource" : {
+#           "type" : "cloudwatch",
+#           "uid" : grafana_data_source.cloudwatch.uid
+#         },
+#         "fieldConfig" : {
+#           "defaults" : {
+#             "color" : {
+#               "mode" : "palette-classic"
+#             },
+#             "custom" : {
+#               "axisLabel" : "",
+#               "axisPlacement" : "auto",
+#               "barAlignment" : 0,
+#               "drawStyle" : "line",
+#               "fillOpacity" : 0,
+#               "gradientMode" : "none",
+#               "hideFrom" : {
+#                 "legend" : false,
+#                 "tooltip" : false,
+#                 "viz" : false
+#               },
+#               "lineInterpolation" : "linear",
+#               "lineWidth" : 1,
+#               "pointSize" : 5,
+#               "scaleDistribution" : {
+#                 "type" : "linear"
+#               },
+#               "showPoints" : "auto",
+#               "spanNulls" : false,
+#               "stacking" : {
+#                 "group" : "A",
+#                 "mode" : "none"
+#               },
+#               "thresholdsStyle" : {
+#                 "mode" : "off"
+#               }
+#             },
+#             "mappings" : [],
+#             "thresholds" : {
+#               "mode" : "absolute",
+#               "steps" : [
+#                 {
+#                   "color" : "green",
+#                   "value" : null
+#                 },
+#                 {
+#                   "color" : "red",
+#                   "value" : 80
+#                 }
+#               ]
+#             }
+#           },
+#           "overrides" : []
+#         },
+#         "gridPos" : {
+#           "h" : 9,
+#           "w" : 7,
+#           "x" : 14,
+#           "y" : 18
+#         },
+#         "id" : 4,
+#         "options" : {
+#           "legend" : {
+#             "calcs" : [],
+#             "displayMode" : "list",
+#             "placement" : "bottom"
+#           },
+#           "tooltip" : {
+#             "mode" : "single",
+#             "sort" : "none"
+#           }
+#         },
+#         "targets" : [
+#           {
+#             "alias" : "",
+#             "datasource" : {
+#               "type" : "cloudwatch",
+#               "uid" : grafana_data_source.cloudwatch.uid
+#             },
+#             "dimensions" : {
+#               "LoadBalancer" : local.load_balancer
+#             },
+#             "expression" : "",
+#             "id" : "",
+#             "matchExact" : true,
+#             "metricEditorMode" : 0,
+#             "metricName" : "HTTPCode_ELB_4XX_Count",
+#             "metricQueryType" : 0,
+#             "namespace" : "AWS/ApplicationELB",
+#             "period" : "",
+#             "queryMode" : "Metrics",
+#             "refId" : "A",
+#             "region" : "default",
+#             "sqlExpression" : "",
+#             "statistic" : "Sum"
+#           },
+#           {
+#             "alias" : "",
+#             "datasource" : {
+#               "type" : "cloudwatch",
+#               "uid" : grafana_data_source.cloudwatch.uid
+#             },
+#             "dimensions" : {
+#               "LoadBalancer" : local.load_balancer
+#             },
+#             "expression" : "",
+#             "id" : "",
+#             "matchExact" : true,
+#             "metricEditorMode" : 0,
+#             "metricName" : "HTTPCode_Target_4XX_Count",
+#             "metricQueryType" : 0,
+#             "namespace" : "AWS/ApplicationELB",
+#             "period" : "",
+#             "queryMode" : "Metrics",
+#             "refId" : "B",
+#             "region" : "default",
+#             "sqlExpression" : "",
+#             "statistic" : "Sum"
+#           }
+#         ],
+#         "title" : "4XX",
+#         "type" : "timeseries"
+#       }
+#     ],
+#     "schemaVersion" : 35,
+#     "style" : "dark",
+#     "tags" : [],
+#     "templating" : {
+#       "list" : []
+#     },
+#     "time" : {
+#       "from" : "now-6h",
+#       "to" : "now"
+#     },
+#     "timepicker" : {},
+#     "timezone" : "",
+#     "title" : "${var.app_name} - ${var.environment} - old",
+#     "uid" : "${var.app_name}-${var.environment}-old",
+#     "version" : 13,
+#     "weekStart" : ""
+#   })
+# }

--- a/terraform/monitoring/panels/app/postgres_query_latency.libsonnet
+++ b/terraform/monitoring/panels/app/postgres_query_latency.libsonnet
@@ -1,25 +1,25 @@
-local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
-local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+local defaults = import '../../grafonnet-lib/defaults.libsonnet';
+local grafana = import '../../grafonnet-lib/grafana.libsonnet';
 
-local panels    = grafana.panels;
-local targets   = grafana.targets;
+local panels = grafana.panels;
+local targets = grafana.targets;
 
 {
   new(ds, vars)::
     panels.timeseries(
-      title       = 'Postgres Query Latency',
-      datasource  = ds.prometheus,
+      title='Postgres Query Latency',
+      datasource=ds.prometheus,
     )
     .configure(
       defaults.configuration.timeseries
-        .withUnit('ms')
+      .withUnit('ms')
     )
 
     .addTarget(targets.prometheus(
-      datasource    = ds.prometheus,
-      expr          = 'sum by (aws_ecs_task_revision, name) (rate(postgres_query_latency_sum[$__rate_interval])) / sum by (aws_ecs_task_revision, name) (rate(postgres_query_latency_count[$__rate_interval]))',
-      legendFormat  = '{{name}} r{{aws_ecs_task_revision}}',
-      exemplar      = false,
-      refId         = 'PostgresQueryLatency',
-    ))
+      datasource=ds.prometheus,
+      expr='sum by (aws_ecs_task_revision, name) (rate(postgres_query_latency_sum[$__rate_interval])) / sum by (aws_ecs_task_revision, name) (rate(postgres_query_latency_count[$__rate_interval]))',
+      legendFormat='{{name}} r{{aws_ecs_task_revision}}',
+      exemplar=false,
+      refId='PostgresQueryLatency',
+    )),
 }

--- a/terraform/monitoring/panels/app/postgres_query_rate.libsonnet
+++ b/terraform/monitoring/panels/app/postgres_query_rate.libsonnet
@@ -1,33 +1,33 @@
-local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
-local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+local defaults = import '../../grafonnet-lib/defaults.libsonnet';
+local grafana = import '../../grafonnet-lib/grafana.libsonnet';
 
-local panels    = grafana.panels;
-local targets   = grafana.targets;
+local panels = grafana.panels;
+local targets = grafana.targets;
 
 {
   new(ds, vars)::
     panels.timeseries(
-      title       = 'Postgres Query Rate',
-      datasource  = ds.prometheus,
+      title='Postgres Query Rate',
+      datasource=ds.prometheus,
     )
     .configure(
       defaults.configuration.timeseries
-        .withUnit('cps')
+      .withUnit('cps')
     )
 
     .addTarget(targets.prometheus(
-      datasource    = ds.prometheus,
-      expr          = 'sum by (aws_ecs_task_revision, name) (rate(postgres_queries_total[$__rate_interval]))',
-      legendFormat  = '{{name}} r{{aws_ecs_task_revision}}',
-      exemplar      = true,
-      refId         = 'PostgresQueryRate',
+      datasource=ds.prometheus,
+      expr='sum by (aws_ecs_task_revision, name) (rate(postgres_queries_total[$__rate_interval]))',
+      legendFormat='{{name}} r{{aws_ecs_task_revision}}',
+      exemplar=true,
+      refId='PostgresQueryRate',
     ))
 
     .addTarget(targets.prometheus(
-      datasource    = ds.prometheus,
-      expr          = 'sum(rate(postgres_queries_total[$__rate_interval]))',
-      legendFormat  = 'r{{aws_ecs_task_revision}}',
-      exemplar      = true,
-      refId         = 'PostgresQueryRateTotal',
-    ))
+      datasource=ds.prometheus,
+      expr='sum(rate(postgres_queries_total[$__rate_interval]))',
+      legendFormat='r{{aws_ecs_task_revision}}',
+      exemplar=true,
+      refId='PostgresQueryRateTotal',
+    )),
 }

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -1,8 +1,6 @@
-local panels = (import '../grafonnet-lib/defaults.libsonnet').panels;
-
 {
   app: {
-    postgres_query_rate:                        (import 'app/postgres_query_rate.libsonnet'                        ).new,
-    postgres_query_latency:                     (import 'app/postgres_query_latency.libsonnet'                     ).new,
+    postgres_query_rate: (import 'app/postgres_query_rate.libsonnet').new,
+    postgres_query_latency: (import 'app/postgres_query_latency.libsonnet').new,
   },
 }

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -1,3 +1,8 @@
+variable "region" {
+  type    = string
+  default = "eu-central-1"
+}
+
 variable "app_name" {
   type = string
 }
@@ -17,4 +22,9 @@ variable "load_balancer_arn" {
 variable "notification_channels" {
   description = "The notification channels to send alerts to"
   type        = list(any)
+}
+
+variable "monitoring_role_arn" {
+  description = "The ARN of the monitoring role."
+  type        = string
 }

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -17,12 +17,6 @@ provider "grafana" {
   auth = var.grafana_auth
 }
 
-provider "grafana" {
-  alias = "sla"
-  url   = "https://${data.terraform_remote_state.monitoring.outputs.grafana_workspaces.business.grafana_endpoint}"
-  auth  = var.sla_grafana_auth
-}
-
 provider "random" {}
 
 provider "github" {}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -17,6 +17,12 @@ provider "grafana" {
   auth = var.grafana_auth
 }
 
+provider "grafana" {
+  alias = "sla"
+  url   = "https://${data.terraform_remote_state.monitoring.outputs.grafana_workspaces.business.grafana_endpoint}"
+  auth  = var.sla_grafana_auth
+}
+
 provider "random" {}
 
 provider "github" {}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,7 +14,13 @@ variable "public_url" {
 }
 
 variable "grafana_auth" {
-  type = string
+  type      = string
+  sensitive = true
+}
+
+variable "sla_grafana_auth" {
+  type      = string
+  sensitive = true
 }
 
 variable "image_version" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,6 +3,11 @@ variable "region" {
   default = "eu-central-1"
 }
 
+variable "environment" {
+  type    = string
+  default = "staging"
+}
+
 variable "azs" {
   type    = list(string)
   default = ["eu-central-1a", "eu-central-1b", "eu-central-1c"]
@@ -14,11 +19,6 @@ variable "public_url" {
 }
 
 variable "grafana_auth" {
-  type      = string
-  sensitive = true
-}
-
-variable "sla_grafana_auth" {
   type      = string
   sensitive = true
 }


### PR DESCRIPTION
# Description

Moves data source definitions to [Grafana Central](https://g-aa89c04cfd.grafana-workspace.eu-central-1.amazonaws.com/login)

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update