### PR TITLE
fix(apns): handling of the certificate expiration error

### DIFF
--- a/src/providers/apns.rs
+++ b/src/providers/apns.rs
@@ -175,6 +175,10 @@ impl PushProvider for ApnsProvider {
                             );
                             Err(Error::ApnsCertificateUnknownCA)
                         }
+                        dbg if dbg.contains("received fatal alert: CertificateExpired") => {
+                            info!("APNs certificate expired: debug:{dbg}, display: {client_error}");
+                            Err(Error::ApnsCertificateExpired)
+                        }
                         _ => Err(Error::Apns(e)),
                     }
                 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -79,11 +79,7 @@ pub fn new_state(
     #[cfg(feature = "multitenant")]
     let jwt_secret = config.jwt_secret.clone();
 
-    let public_ip = match networking::find_public_ip_addr() {
-        Ok(ip) => Some(ip),
-        // Note: Should we pass this error back up?
-        Err(_e) => None,
-    };
+    let public_ip = networking::find_public_ip_addr().ok();
 
     Ok(AppState {
         config: config.clone(),


### PR DESCRIPTION
# Description

This PR adds proper handling of the `received fatal alert: CertificateExpired` APNS error.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update