### PR TITLE
fix(CI): updating the cache version and fixing permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         continue-on-error: false
 
       - name: Cache sccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         continue-on-error: false
         with:
           path: ${{ matrix.sccache-path }}

--- a/.github/workflows/ci_terraform.yml
+++ b/.github/workflows/ci_terraform.yml
@@ -17,6 +17,9 @@ concurrency:
   # If there is already a workflow running for the same pull request, cancel it
   cancel-in-progress: ${{ github.event.type == 'PullRequest' }}
 
+permissions:
+  contents: write
+
 jobs:
   check-fmt:
     runs-on: ubuntu-latest
@@ -81,9 +84,6 @@ jobs:
     needs:
       - get-version
     runs-on: ubuntu-latest
-    permissions:
-      contents: 'read'
-      pull-requests: 'write'
     environment:
       name: staging
       url: https://staging.echo.walletconnect.com/health


### PR DESCRIPTION
# Description

This PR updates the `actions/cache` version from 2 to 3 to fix the CI workflow error.
Moving permission to write to the top level to support the updated `checkout@v4`.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update