### PR TITLE
feat: replicate push-server dashboards on Grafana Cloud

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -63,17 +63,6 @@ jobs:
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
-      - name: Get Grafana details
-        id: grafana-get-details
-        uses: WalletConnect/actions/aws/grafana/get-details/@1.0.3
-
-      - name: Get Grafana key
-        id: grafana-get-key
-        uses: WalletConnect/actions/aws/grafana/get-key/@1.0.3
-        with:
-          key-prefix: ${{ github.event.repository.name }}
-          workspace-id: ${{ steps.grafana-get-details.outputs.workspace-id }}
-
       - name: Init Terraform
         id: tf-init
         uses: WalletConnect/actions/terraform/init/@1.0.3
@@ -84,21 +73,11 @@ jobs:
         id: tf-apply
         uses: WalletConnect/actions/terraform/apply/@1.0.3
         env:
-          TF_VAR_grafana_auth: ${{ steps.grafana-get-key.outputs.key }}
-          TF_VAR_grafana_endpoint: ${{ steps.grafana-get-details.outputs.endpoint }}
           TF_VAR_jwt_secret: ${{ secrets.STAGING_JWT_SECRET }}
           TF_VAR_image_version: ${{ inputs.image_tag }}
           TF_VAR_relay_public_key: ${{ secrets.RELAY_PUBLIC_KEY }}
         with:
           environment: "staging"
-
-      - name: Delete Grafana key
-        id: grafana-delete-key
-        uses: WalletConnect/actions/aws/grafana/delete-key/@1.0.3
-        if: ${{ success() || failure() || cancelled() }} # don't use always() since it creates non-cancellable jobs
-        with:
-          key-name: ${{ steps.grafana-get-key.outputs.key-name }}
-          workspace-id: ${{ steps.grafana-get-details.outputs.workspace-id }}
 
   validate_staging:
     if: ${{ inputs.deploy_to_staging }}
@@ -136,17 +115,6 @@ jobs:
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
-      - name: Get Grafana details
-        id: grafana-get-details
-        uses: WalletConnect/actions/aws/grafana/get-details/@1.0.3
-
-      - name: Get Grafana key
-        id: grafana-get-key
-        uses: WalletConnect/actions/aws/grafana/get-key/@1.0.3
-        with:
-          key-prefix: ${{ github.event.repository.name }}
-          workspace-id: ${{ steps.grafana-get-details.outputs.workspace-id }}
-
       - name: Init Terraform
         id: tf-init
         uses: WalletConnect/actions/terraform/init/@1.0.3
@@ -157,18 +125,8 @@ jobs:
         id: tf-apply
         uses: WalletConnect/actions/terraform/apply/@1.0.3
         env:
-          TF_VAR_grafana_auth: ${{ steps.grafana-get-key.outputs.key }}
-          TF_VAR_grafana_endpoint: ${{ steps.grafana-get-details.outputs.endpoint }}
           TF_VAR_jwt_secret: ${{ secrets.PROD_JWT_SECRET }}
           TF_VAR_image_version: ${{ inputs.image_tag }}
           TF_VAR_relay_public_key: ${{ secrets.RELAY_PUBLIC_KEY }}
         with:
           environment: "prod"
-
-      - name: Delete Grafana key
-        id: grafana-delete-key
-        uses: WalletConnect/actions/aws/grafana/delete-key/@1.0.3
-        if: ${{ success() || failure() || cancelled() }} # don't use always() since it creates non-cancellable jobs
-        with:
-          key-name: ${{ steps.grafana-get-key.outputs.key-name }}
-          workspace-id: ${{ steps.grafana-get-details.outputs.workspace-id }}

--- a/.github/workflows/ci_terraform.yml
+++ b/.github/workflows/ci_terraform.yml
@@ -51,33 +51,22 @@ jobs:
     outputs:
       version: ${{ steps.clean_version.outputs.version }}
     steps:
-      #TODO: Authenticate to avoid API rate limit exceeded errors.
+      # Replaces pozetroninc/github-action-get-latest-release@master, which queries the
+      # API unauthenticated and 403s on the shared per-IP limit (the TODO that used to
+      # sit here). gh is preinstalled and GITHUB_TOKEN gets the authenticated quota;
+      # `gh release view` skips drafts, as `excludes: draft` did.
       - name: Get latest release for image version
-        id: latest_release
-        uses: pozetroninc/github-action-get-latest-release@master
-        with:
-          repository: ${{ github.repository }}
-          excludes: draft
-
-      - name: Get release value
-        id: get_value
-        uses: actions/github-script@v6
-        env:
-          LATEST_TAG: ${{ steps.latest_release.outputs.release }}
-        with:
-          result-encoding: string
-          script: |
-            if (context.eventName == "release") {
-              return context.payload.release.tag_name
-            } else {
-              return process.env.LATEST_TAG
-            }
-
-      - name: Clean version
         id: clean_version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
         run: |
-          version=$(echo "${{ steps.get_value.outputs.result }}" | sed 's/v//g')
-          echo "version=$version" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          tag="$RELEASE_TAG"
+          if [ -z "$tag" ]; then
+            tag=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)
+          fi
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
 
   plan-staging:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci_terraform.yml
+++ b/.github/workflows/ci_terraform.yml
@@ -107,17 +107,6 @@ jobs:
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
-      - name: Get Grafana details
-        id: grafana-get-details
-        uses: WalletConnect/actions/aws/grafana/get-details/@2.5.4
-
-      - name: Get Grafana key
-        id: grafana-get-key
-        uses: WalletConnect/actions/aws/grafana/get-key/@2.5.4
-        with:
-          key-prefix: ${{ github.event.repository.name }}-staging
-          workspace-id: ${{ steps.grafana-get-details.outputs.workspace-id }}
-
       - name: Init Terraform
         id: tf-init
         uses: WalletConnect/actions/terraform/init/@2.5.4
@@ -128,18 +117,8 @@ jobs:
         id: tf-plan-staging
         uses: WalletConnect/actions/terraform/plan/@2.5.4
         env:
-          TF_VAR_grafana_auth: ${{ steps.grafana-get-key.outputs.key }}
-          TF_VAR_grafana_endpoint: ${{ steps.grafana-get-details.outputs.endpoint }}
           TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
           TF_VAR_relay_public_key: ${{ secrets.RELAY_PUBLIC_KEY }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           environment: staging
-
-      - name: Delete Grafana key
-        id: grafana-delete-key
-        uses: WalletConnect/actions/aws/grafana/delete-key/@2.5.4
-        if: ${{ success() || failure() || cancelled() }} # don't use always() since it creates non-cancellable jobs
-        with:
-          key-name: ${{ steps.grafana-get-key.outputs.key-name }}
-          workspace-id: ${{ steps.grafana-get-details.outputs.workspace-id }}

--- a/.github/workflows/ci_terraform.yml
+++ b/.github/workflows/ci_terraform.yml
@@ -113,12 +113,24 @@ jobs:
         with:
           environment: staging
 
+      # Not WalletConnect/actions/terraform/plan: it runs `plan -out=/tmp/plan.tfplan`,
+      # and the remote backend refuses to save a plan locally ("Saving a generated plan
+      # is currently not supported") because echo-server-* are remote-execution
+      # workspaces. Plan inline instead, as ci_workflows/ci-plan-infra.yml does. All
+      # variables come from the TFC workspace, so no -var-file and no TF_VAR_* here.
       - name: Run Terraform Plan
         id: tf-plan-staging
-        uses: WalletConnect/actions/terraform/plan/@2.5.4
         env:
-          TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
-          TF_VAR_relay_public_key: ${{ secrets.RELAY_PUBLIC_KEY }}
+          TF_WORKSPACE: staging
+          TF_IN_AUTOMATION: "true"
+        run: |
+          set -o pipefail
+          terraform -chdir=terraform plan -no-color 2>&1 | tee /tmp/plan_output.txt
+
+      - name: Upload Plan Output
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          environment: staging
+          name: terraform-plan-staging
+          path: /tmp/plan_output.txt
+          retention-days: 1

--- a/.github/workflows/ci_terraform.yml
+++ b/.github/workflows/ci_terraform.yml
@@ -113,6 +113,20 @@ jobs:
         with:
           environment: staging
 
+      # Remote-execution workspaces ignore runner-side TF_VAR_*, but *.auto.tfvars.json
+      # is part of the uploaded configuration and is read by the remote run. jwt_secret
+      # and relay_public_key are not set on the TFC workspace (grafana_auth and
+      # grafana_cloud_token are), so inject them here — the ci_workflows tf-vars
+      # pattern, with jq for correct escaping. Git ignores *.tfvars.json.
+      - name: Configure Terraform Variables
+        working-directory: terraform
+        env:
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          RELAY_PUBLIC_KEY: ${{ secrets.RELAY_PUBLIC_KEY }}
+        run: |
+          jq -n --arg jwt "$JWT_SECRET" --arg relay "$RELAY_PUBLIC_KEY" \
+            '{jwt_secret: $jwt, relay_public_key: $relay}' > plan.auto.tfvars.json
+
       # Not WalletConnect/actions/terraform/plan: it runs `plan -out=/tmp/plan.tfplan`,
       # and the remote backend refuses to save a plan locally ("Saving a generated plan
       # is currently not supported") because echo-server-* are remote-execution

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/alxrem/jsonnet" {
-  version     = "2.3.1"
+  version     = "2.3.2"
   constraints = "~> 2.3.0"
   hashes = [
-    "h1:hhgft+XkSDE5ayFLJEGeyQtH8SDnVIh96XcLISmSP9U=",
-    "h1:nJWe8MlT7oGpKf3j0GL4RJsk02b+8XIjCGtLO58L2Sk=",
-    "zh:07479550eb7604605d943cc31fa96b002624be63a1c0c04d3bed350af9ef3543",
-    "zh:0b8eba2be9a162f0cc78a5911f760dfefdd78b50ecc785710a98e86f933b53a4",
-    "zh:0e320d005a8730a0c1ed65a3bf3bb4bb8c35d4a19005f43e0442cfa3b62622e5",
-    "zh:10861809d729f74acb773d71d251160449b1acc728a3710d43ddc2b31b3f09f7",
-    "zh:24fad4bd096d8386b1dc27e6d4296086fb275c0dc6f25814077eb6cdc8146389",
-    "zh:2a9bca30f084fa992ef614ebf0ceaf83145890fdef005220541d4c889e935cc0",
-    "zh:3602b01d339a322d8366f23ff1836ca9438091c6bc3de12a0f7679b9650ceaa6",
-    "zh:402adf2f5bb2d6724405b22f2a81a6cff3059598fb8dbc93aa1d2a4cf09aa888",
-    "zh:70768655d9f24aba48ccacdbd1ea4318c0dc1f0077f8f7c4e7edb6f2edb90b6d",
-    "zh:73d84e10ce8211c18342aebd89eab8f3085ddcb48ec846d7368c80d94b8ebe4e",
-    "zh:775540195cb6e94b23459dd51e6b9d33c2992040be86d4db227a295ca0b5023a",
-    "zh:bc350b6529bf07e72479ef3098382e89464a68d956af397414a8ef6c66482048",
-    "zh:e82ffb1c7aff7bc9cf8f4ff7452207c690a19294844653900b6a3b7e73bf68ea",
-    "zh:ff9c40d558b7782370bf4147a78600e7a430fbf44a4bdde89c33475336bc9a53",
+    "h1:382Ls1U6Td9ygPFrjGnsj0J6YKv2V3t3TOgNmeiYSSQ=",
+    "h1:kLaM/dGJ9IfBw2UQ3wpBWeuP/oISSwgoQKKgvHHWo+k=",
+    "zh:11d3c329581ac045c59f96cbeec67413c8496e2b65f39133d74c3d5294e01c48",
+    "zh:2332a9d3910a951917c8783856c010ebfa058973775d8d97811279d50b9c67c0",
+    "zh:3cf37cf75644b8f30f5400fe9e0ffade1971ae28c4f90398b4efb381763fe45b",
+    "zh:41df1b211210e5c1f083eeb393b1236a32b29e9a2ef0a52791d25d80d60e9f05",
+    "zh:5a5256af803b7f6efac1b76494c7fbd9ae6100452e3e537f53fd474b6b14df76",
+    "zh:5af451895b4e1762825127570f9a361ee76827bb8aef7184ca6c62df566f1c72",
+    "zh:5d8777bdbfed29a6d6141520036202d08cd29cddabfff8317cb1c61d57b7f80e",
+    "zh:5f8ce0e10ec885b581f2e63d195aed23ca7729554cfdcd0c4acb77b193e0844d",
+    "zh:8c2254887190a7ef3119d3592789f2344beeda60f25ebc93fe7a1cc81a576284",
+    "zh:99af2ed1ae1acfe30ede44730f29e37a309a65050e77cf327a03a647c3fe25d4",
+    "zh:af7121b7aa529e49c3922007e761eeb3a9edb4cd7d399c5098a6645299f4c24e",
+    "zh:be338f56766ce7bb2d8830259266a91b105428c3e0aa5b7a1c17143a13e1c74a",
+    "zh:d17d3da7e8b36c124762478e7444a86a7240d30c14e7ec40d6fa5e0d4f1256b4",
+    "zh:eb1878738514aaad15894b6833bb66fa64def7471071dc2ade7e1c8c5d6bf59f",
   ]
 }
 
@@ -45,31 +45,36 @@ provider "registry.terraform.io/bwoznicki/assert" {
 }
 
 provider "registry.terraform.io/grafana/grafana" {
-  version     = "2.19.0"
-  constraints = "~> 2.0, >= 2.1.0"
+  version     = "4.45.2"
+  constraints = ">= 3.0.0, < 5.0.0"
   hashes = [
-    "h1:L9A5My0gdANUlMsjuN15MGtoiHmDgxwbtWMolRYkNQE=",
-    "h1:Rqn7cIJs9cU+V7Dus2cQwl5HaFhnUAZoZrly3oz9UlM=",
-    "zh:0f85e0602ccf119a203f47ee18524a8172457e82b8cbffca7b6b4d7f474639ad",
-    "zh:1a626e0d04dedd48cb5b0bdf8a68f428fdf0f7080128928dfaa293a4db78b9b3",
-    "zh:2a4de32569e070de38faa3d3224ab7fe0a837809d70d75dedc8f1f1f8d9dc227",
-    "zh:3c3b77436da2fc8ff428ee7dae44d0bc820ebf835c951de4ed1052b68431081f",
-    "zh:404de4f0e0bb7fe9b6f95187a69e4d9a9e6ba452bba7a62c62c15f154136c2b2",
-    "zh:6a247dea12ade810c5f74528bac5ffeb7a4c9d54089e1a42134e34b193fddc32",
-    "zh:90d795e190f1374bde468e90014dcd818e65f66b21cd518487f84cec7bc842c9",
-    "zh:9e2e846bb354fe8b041913e55211f95bb9d8246ec426e7c589c87f1b4e0573c5",
-    "zh:a43e2f0cc5fb76dbf508b3f66061d67b469bd248a557f05d3c7f43b7a45041c0",
-    "zh:b90e3120face56f753933ecabd5b80131679c444b72ab53d0e40263be684eab6",
-    "zh:bdb35128710a6f45c8e473b9c0171f6cb7ae5cf572ca72561d0543a4dca3e609",
-    "zh:c786b6e95597c677f6d6e5e994376889b17635df512fe2798902b0ee3fd63367",
-    "zh:cb3d7f28a1eb696607b3d799a6b6b2ac5914240e61b578c7b45e42eb76979481",
-    "zh:f106de3485bcd1af0dbf45ffd475ec60c452cb39df51e2e550eb4ab4cf1e0f73",
+    "h1:S3yVR51788AurIw+0Pbwx/fFCFdTGSIWe+Jp/C8lkVc=",
+    "h1:tySsPdFSi/b6WBPgd3c2eOjH3kOi4INrh7OPIXA26sM=",
+    "zh:00df848de76f279769ea39f4211df9b4371f36965f6d953b2c2cbb3db7b56f5b",
+    "zh:28050fdd68ed79fbfc571d1974551d0f60e9e5f6eb27f70d188d242524d8a4f4",
+    "zh:2b90bc1c1302d271d63971a768c398f07e0b99fe942d853b74d5be2fac6ef33b",
+    "zh:392cad7ad35f6b0def35c548d2b2aab41f37d187e299d36ef12987a965f56d26",
+    "zh:458b3e22a4add9ee623ecd2b2bbbccdaaee4bde471cf7b56b94409368b23b103",
+    "zh:4b14c5c5068cc59756f62c1e793faa8a1e249f1cfbe63c7a2c4eeacde62cb59e",
+    "zh:630f3431d807b22094fa9af209856b2f90f51296bff0a6ad6d4509203d66742f",
+    "zh:83650ae8ca8f9436fa4ceb6d8501d15769bf6fccb915880058c06f100428bf98",
+    "zh:8820aef63222aadca0f1fb185cf5f0aead3396ba88341e3578fd1ebe3c5a70f1",
+    "zh:8ef30b6468e168e1573739871dc4c921aef5dc1cdce537bf3e84fea52a0edb5f",
+    "zh:9669217bf56f2305ac72c707ad1a1f0f4dfbc3cf1aadd56d74a6b5f1a5d70f34",
+    "zh:97c58572e862cb19a741cd0d18d7b3699afc598ffa569a7a51903beb57feb81c",
+    "zh:a2ef5c734a5c926561c8d77d435adf01252aa565f6243ab8c8d6f5f5005e3392",
+    "zh:a3427dfc698e872b62fdb1fb48fe12370ba960fb342b558934b5f5fc869a35f7",
+    "zh:a5ae94da3b34e7cd49378616a3c3af2061d5080cdd270de2c1cc0c87377050e6",
+    "zh:cedd7188a479d2a90ececd9ebc5c80cbbd048fdc8e9cb3cded66d31c5c680f0e",
+    "zh:ddff90ee7588e418c2224384e8ae034f6138fce6f7da5228a76d52bbba26bd01",
+    "zh:f0f0a955a3f53c8e49c6289215588dc38237693a3259f564337d16ffe1adf15f",
+    "zh:fc92c2a6a87baf547029483c95f2fddb71a2e55c315e5111feee4b836b191e28",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.67.0"
-  constraints = ">= 3.73.0, >= 4.30.0, ~> 4.31"
+  constraints = ">= 3.73.0, >= 4.30.0, ~> 4.31, >= 4.50.0"
   hashes = [
     "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
     "h1:dCRc4GqsyfqHEMjgtlM1EympBcgTmcTkWaJmtd91+KA=",

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -19,8 +19,11 @@ terraform {
       version = "~> 4.31"
     }
     grafana = {
-      source  = "grafana/grafana"
-      version = ">= 2.1"
+      source = "grafana/grafana"
+      # Bumped from ">= 2.1"/module "~> 2.0" (lock 2.19.0) for the AMG -> Grafana Cloud
+      # dual-run: the aliased grafana.cloud + grafana_assume_role datasources need a modern
+      # provider. Resource types used (data_source/dashboard) are stable 2.x->4.x.
+      version = ">= 3.0, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -187,11 +187,20 @@ module "ecs" {
 module "monitoring" {
   source = "./monitoring"
 
-  app_name                = "${local.environment}-${local.app_name}"
-  prometheus_workspace_id = aws_prometheus_workspace.prometheus.id
-  load_balancer_arn       = module.ecs.load_balancer_arn
-  environment             = local.environment
-  notification_channels   = var.notification_channels
+  # AMG -> Grafana Cloud migration dual-run: pass the aliased grafana.cloud (aliased
+  # providers are never auto-inherited). default grafana -> AMG, grafana.cloud -> Cloud.
+  # The default aws (wc-main) is inherited automatically.
+  providers = {
+    grafana       = grafana
+    grafana.cloud = grafana.cloud
+  }
+
+  app_name                 = "${local.environment}-${local.app_name}"
+  prometheus_workspace_id  = aws_prometheus_workspace.prometheus.id
+  prometheus_workspace_arn = aws_prometheus_workspace.prometheus.arn
+  load_balancer_arn        = module.ecs.load_balancer_arn
+  environment              = local.environment
+  notification_channels    = var.notification_channels
 
   region              = var.region
   monitoring_role_arn = data.terraform_remote_state.monitoring.outputs.grafana_workspaces.central.iam_role_arn

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -58,3 +58,140 @@ resource "grafana_dashboard" "push_server" {
   config_json = data.jsonnet_file.dashboard.rendered
 }
 
+################################################################
+################################################################
+# GRAFANA CLOUD TWINS (migration dual-run)
+# Byte-identical copies of the AMG resources above,
+# provider = grafana.cloud. AMG blocks above remain the live
+# paging path until this unit's route source-flip. At AMG
+# teardown the AMG blocks above are deleted; these twins remain.
+################################################################
+################################################################
+# NOTE: push is DASHBOARDS-ONLY (0 alert rules, no folder, no rule group, no incident
+# route). There is no later route source-flip for this unit — it completes at dashboard
+# parity + sign-off. The banner's "paging path" wording is the shared template; push does
+# not page. The AMG blocks above are still deleted at teardown; these twins remain.
+
+# Dedicated CREATE_ROLE for Grafana Cloud. NOT ADD_TRUST on the AMG-era
+# eu-central-1-<env>-push-monitoring role: that role is destroyed at AMG teardown, which
+# would break Cloud. This Cloud-only role survives teardown. It carries BOTH CloudWatch
+# read AND aps:Query* (push has an AMP datasource).
+# CONFUSED-DEPUTY GUARD: the trust pins sts:ExternalId so only our Grafana Cloud stack can
+# assume it. Principal + ExternalId read from the live mx-prod-grafana-cloudwatch trust.
+locals {
+  grafana_cloud_role_name = "push-${var.environment}-grafana-cloudwatch"
+  cloud_prometheus_uid    = { prod = "wBlpDqaNk", staging = "7EUBUu-Nk" }[var.environment]
+  cloud_cloudwatch_uid    = { prod = "MqQtD3aNz", staging = "b6yf8X-Nk" }[var.environment]
+}
+
+resource "aws_iam_role" "grafana_cloud" {
+  name = local.grafana_cloud_role_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { AWS = var.grafana_cloud_principal_arn }
+        Action    = "sts:AssumeRole"
+        Condition = {
+          StringEquals = { "sts:ExternalId" = var.grafana_cloud_external_id }
+        }
+      }
+    ]
+  })
+
+  tags = module.this.tags
+}
+
+resource "aws_iam_role_policy_attachment" "grafana_cloud_cloudwatch" {
+  role       = aws_iam_role.grafana_cloud.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonGrafanaCloudWatchAccess"
+}
+
+resource "aws_iam_role_policy" "grafana_cloud_amp_read" {
+  name = "amp-query"
+  role = aws_iam_role.grafana_cloud.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "aps:QueryMetrics",
+          "aps:GetLabels",
+          "aps:GetSeries",
+          "aps:GetMetricMetadata"
+        ]
+        Resource = var.prometheus_workspace_arn
+      }
+    ]
+  })
+}
+
+# Cloud AMP reader — twin of grafana_data_source.prometheus. uid preserved (== AMG uid) so
+# the dashboard's prometheus_uid resolves unchanged. Grafana Cloud assumes the dedicated
+# role via grafana_assume_role (instead of the AMG monitoring-role's ec2_iam_role).
+resource "grafana_data_source" "cloud_prometheus" {
+  provider = grafana.cloud
+
+  type = "prometheus"
+  name = "${var.app_name}-amp"
+  url  = "https://aps-workspaces.eu-central-1.amazonaws.com/workspaces/${var.prometheus_workspace_id}/"
+  uid  = local.cloud_prometheus_uid
+
+  json_data_encoded = jsonencode({
+    httpMethod         = "GET"
+    manageAlerts       = false
+    sigV4Auth          = true
+    sigV4AuthType      = "grafana_assume_role"
+    sigV4Region        = "eu-central-1"
+    sigV4AssumeRoleArn = aws_iam_role.grafana_cloud.arn
+  })
+
+  depends_on = [aws_iam_role_policy.grafana_cloud_amp_read]
+}
+
+# Cloud CloudWatch — twin of grafana_data_source.cloudwatch. uid preserved.
+resource "grafana_data_source" "cloud_cloudwatch" {
+  provider = grafana.cloud
+
+  type = "cloudwatch"
+  name = "${var.app_name}-cloudwatch"
+  uid  = local.cloud_cloudwatch_uid
+
+  json_data_encoded = jsonencode({
+    defaultRegion = "eu-central-1"
+    authType      = "grafana_assume_role"
+    assumeRoleArn = aws_iam_role.grafana_cloud.arn
+  })
+
+  depends_on = [aws_iam_role_policy_attachment.grafana_cloud_cloudwatch]
+}
+
+# Dashboard twin — same dashboard.jsonnet, uids point at the Cloud datasources
+# (teardown-safe). Preserved uids -> byte-identical rendered config_json. No folder.
+data "jsonnet_file" "dashboard_cloud" {
+  source = "${path.module}/dashboard.jsonnet"
+
+  ext_str = {
+    dashboard_title = "Push Server - ${title(var.environment)}"
+    dashboard_uid   = "push-${var.environment}"
+
+    prometheus_uid = grafana_data_source.cloud_prometheus.uid
+    cloudwatch_uid = grafana_data_source.cloud_cloudwatch.uid
+
+    environment   = var.environment
+    notifications = jsonencode(var.notification_channels)
+  }
+}
+
+resource "grafana_dashboard" "push_server_cloud" {
+  provider = grafana.cloud
+
+  overwrite   = true
+  message     = "Updated by Terraform"
+  config_json = data.jsonnet_file.dashboard_cloud.rendered
+}
+

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -136,7 +136,12 @@ resource "aws_iam_role_policy" "grafana_cloud_amp_read" {
 resource "grafana_data_source" "cloud_prometheus" {
   provider = grafana.cloud
 
-  type = "prometheus"
+  # Amazon Managed Prometheus datasource plugin, NOT the plain "prometheus" type. On
+  # Grafana Cloud only this type performs the AWS SigV4 grafana_assume_role into our
+  # account to query AMP; a plain "prometheus" datasource returns 403 (no assume-role),
+  # so the dashboard's AMP panels show no data. Matches every working AMP reader on Cloud
+  # (prod-pay-core-amp, staging-blockchain-api-amp, central cloudflare/supabase, mx-*).
+  type = "grafana-amazonprometheus-datasource"
   name = "${var.app_name}-amp"
   url  = "https://aps-workspaces.eu-central-1.amazonaws.com/workspaces/${var.prometheus_workspace_id}/"
   uid  = local.cloud_prometheus_uid
@@ -144,10 +149,13 @@ resource "grafana_data_source" "cloud_prometheus" {
   json_data_encoded = jsonencode({
     httpMethod         = "GET"
     manageAlerts       = false
+    authType           = "grafana_assume_role"
+    assumeRoleArn      = aws_iam_role.grafana_cloud.arn
+    defaultRegion      = "eu-central-1"
     sigV4Auth          = true
     sigV4AuthType      = "grafana_assume_role"
-    sigV4Region        = "eu-central-1"
     sigV4AssumeRoleArn = aws_iam_role.grafana_cloud.arn
+    sigV4Region        = "eu-central-1"
   })
 
   depends_on = [aws_iam_role_policy.grafana_cloud_amp_read]

--- a/terraform/monitoring/terraform.tf
+++ b/terraform/monitoring/terraform.tf
@@ -2,9 +2,18 @@ terraform {
   required_version = ">= 1.0"
 
   required_providers {
+    # Used by module.monitoring-role (AMG) and by the dedicated grafana-cloud role below.
+    # Match the root pin (~> 4.31) — the IAM resources used are stable across 4.x.
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.31"
+    }
     grafana = {
       source  = "grafana/grafana"
-      version = "~> 2.0"
+      version = ">= 3.0, < 5.0" # was "~> 2.0" (lock 2.19.0); bumped for the Cloud dual-run (see root backend.tf)
+      # Receives the aliased grafana.cloud instance from the root (approach A). Without
+      # this, provider = grafana.cloud on a resource in this module is an error.
+      configuration_aliases = [grafana.cloud]
     }
     jsonnet = {
       source  = "alxrem/jsonnet"

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -15,6 +15,37 @@ variable "prometheus_workspace_id" {
   type = string
 }
 
+# AMP workspace ARN, scoped as the Resource of the dedicated Cloud role's aps:Query* policy
+# (main.tf). Passed from the root (aws_prometheus_workspace.prometheus.arn).
+variable "prometheus_workspace_arn" {
+  description = "ARN of the AMP workspace, for the Grafana Cloud role's aps:Query* policy."
+  type        = string
+}
+
+# Grafana Cloud grafana_assume_role trust inputs (NOT secrets — the public trust contract).
+# Defaults are the live-verified values for our stack, read from mx-prod-grafana-cloudwatch.
+variable "grafana_cloud_principal_arn" {
+  description = "Grafana Labs assume-role account principal that Grafana Cloud uses to assume the per-account datasource role."
+  type        = string
+  default     = "arn:aws:iam::008923505280:root"
+
+  validation {
+    condition     = can(regex("^arn:aws:iam::[0-9]{12}:(root|user/.+|role/.+)$", var.grafana_cloud_principal_arn))
+    error_message = "Must be a valid IAM principal ARN."
+  }
+}
+
+variable "grafana_cloud_external_id" {
+  description = "sts:ExternalId scoping the assume to our Grafana Cloud stack (confused-deputy guard). REQUIRED."
+  type        = string
+  default     = "1464025"
+
+  validation {
+    condition     = length(trimspace(var.grafana_cloud_external_id)) > 0
+    error_message = "grafana_cloud_external_id must be set (confused-deputy guard)."
+  }
+}
+
 variable "load_balancer_arn" {
   type = string
 }

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -17,6 +17,16 @@ provider "grafana" {
   auth = var.grafana_auth
 }
 
+# AMG -> Grafana Cloud migration dual-run (approach A): a SECOND grafana provider
+# instance aliased "cloud", alongside the default AMG provider above. Same module, same
+# TFC workspace, same state. AMG resources stay on the default provider; the Grafana
+# Cloud twins take provider = grafana.cloud. Removed once AMG is torn down.
+provider "grafana" {
+  alias = "cloud"
+  url   = var.grafana_cloud_url
+  auth  = var.grafana_cloud_token
+}
+
 provider "random" {}
 
 provider "github" {}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,6 +23,19 @@ variable "grafana_auth" {
   sensitive = true
 }
 
+# AMG -> Grafana Cloud migration dual-run: the aliased grafana.cloud provider (provider.tf).
+variable "grafana_cloud_url" {
+  description = "Grafana Cloud stack URL (Main Org, prod-eu-west-2)."
+  type        = string
+  default     = "https://walletconnect.grafana.net"
+}
+
+variable "grafana_cloud_token" {
+  description = "Grafana Cloud service-account token for the aliased grafana.cloud provider. Distinct from var.grafana_auth (AMG). Set as a SENSITIVE TFC workspace variable."
+  type        = string
+  sensitive   = true
+}
+
 variable "image_version" {
   type    = string
   default = ""


### PR DESCRIPTION

## Grafana Cloud migration - push-server (dashboards-only, dual-run) + provider bump

Twins push-server's monitoring onto Grafana Cloud alongside AMG (approach A: second aliased `grafana.cloud` provider, same module/workspace). push-server is DASHBOARDS-ONLY (0 alert rules)  so this is the simplest unit and needs NO later route-flip PR.

### What this does
- **Bumps grafana provider 2.19.0 → 4.45.2** (`~> 2.0` → `>= 3.0, < 5.0`). Changelog audited:  no 3.0.0/4.0.0 breaking change touches push-server's usage  clean bump, no-op on AMG.
- Adds an aliased `grafana.cloud` provider + `grafana_cloud_url`/`grafana_cloud_token` vars.
- Creates a dedicated Cloud IAM role per stage (`push-<env>-grafana-cloudwatch`) with  CloudWatch + aps:Query* (push has an AMP datasource), trust `008923505280:root` +  ExternalId `1464025`. New role  survives AMG teardown.
- Adds Grafana Cloud twins, byte-identical to their AMG siblings, in the same file under a  `GRAFANA CLOUD TWINS` banner:
  - 4 datasources (uid-preserved): 2 AMP (prometheus) + 2 CloudWatch
  - 2 dashboards (Push Server prod/staging)
  - No folder, no rule group (dashboards-only).

### Counts
4 datasources · 2 dashboards · 0 alert rules.

### Provider-bump verdict
Clean / no-op on existing AMG resources (validate passes; only the 4 core resource types, all stable 2.x→4.x). Also aligned the module's aws pin to the repo's `~> 4.31`.

### Apply target
TFC workspaces `echo-server-prod` and `echo-server-staging` (org wallet-connect, backend prefix `echo-server-`  push-server was formerly echo-server; the `push-server-*` workspaces are dormant 2023 leftovers and are NOT used). Set the sensitive `grafana_cloud_token` in both.

### Dual-run behavior
The Cloud twin dashboards render off the Cloud datasources; AMG dashboards stay live. There are no alerts, so nothing pages from either side. No `routed_services`, no incident route.

### Review guardrail
Plan shows ONLY additive `grafana.cloud`-aliased resources (2 datasources + 1 dashboard per env) + the new IAM role, with the provider bump a no-es. Zero `incident_*` / central / infra-monitoring-grafana changes.

### Rollback
Revert the branch. Nothing paged, nothing flipped 

 