### PR TITLE
fix(terraform): pin Aurora engine version to the running 13.23

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -78,11 +78,15 @@ module "database_cluster" {
   source  = "terraform-aws-modules/rds-aurora/aws"
   version = "7.7.0"
 
-  name           = "${local.environment}-${local.app_name}-database"
-  engine         = "aurora-postgresql"
-  engine_version = "13.18"
-  engine_mode    = "provisioned"
-  instance_class = "db.serverless"
+  name   = "${local.environment}-${local.app_name}-database"
+  engine = "aurora-postgresql"
+  # Pinned to what the cluster actually runs. AWS auto-upgraded it to 13.23 while this
+  # still said 13.18, so every plan queued an engine_version rollback. Minor upgrades
+  # are a deliberate bump here now, otherwise the drift comes straight back.
+  engine_version             = "13.23"
+  auto_minor_version_upgrade = false
+  engine_mode                = "provisioned"
+  instance_class             = "db.serverless"
   instances = {
     1 = {}
   }
@@ -112,11 +116,13 @@ module "tenant_database_cluster" {
   source  = "terraform-aws-modules/rds-aurora/aws"
   version = "7.7.0"
 
-  name           = "${local.environment}-${local.app_name}-tenant-database"
-  engine         = "aurora-postgresql"
-  engine_version = "13.18"
-  engine_mode    = "provisioned"
-  instance_class = "db.serverless"
+  name   = "${local.environment}-${local.app_name}-tenant-database"
+  engine = "aurora-postgresql"
+  # See database_cluster above: pinned to the running version, auto minor upgrades off.
+  engine_version             = "13.23"
+  auto_minor_version_upgrade = false
+  engine_mode                = "provisioned"
+  instance_class             = "db.serverless"
   instances = {
     1 = {}
   }


### PR DESCRIPTION
Both Aurora clusters declared `engine_version = "13.18"` while AWS had auto-upgraded them to 13.23, so every plan queued a minor-version **rollback** across all four resources:

```
  # module.database_cluster.aws_rds_cluster.this[0] will be updated in-place
      ~ engine_version = "13.23" -> "13.18"
  # module.database_cluster.aws_rds_cluster_instance.this["1"] will be updated in-place
  # module.tenant_database_cluster.aws_rds_cluster.this[0] will be updated in-place
  # module.tenant_database_cluster.aws_rds_cluster_instance.this["1"] will be updated in-place
```

(from the staging plan on #384, the first working plan since March 2025 — visible in run [34378756082](https://github.com/reown-com/push-server/actions/runs/34378756082))

The drift has been harmless only because `plan-staging` was broken that whole time. The next working apply would have executed it against both staging databases.

### Change

- `engine_version` → `"13.23"` on both clusters, matching what they actually run, so the plan is a no-op.
- `auto_minor_version_upgrade = false`, because that is what makes the pin hold. Left at the AWS default of `true`, AWS bumps the minor again at the next maintenance window and the drift comes straight back. Minor upgrades become a deliberate bump of this value.
- `allow_major_version_upgrade` stays `true`, unchanged.

`terraform fmt -check -recursive` is clean (the module block realigned, which is why the diff is wider than the two lines).

> [!IMPORTANT]
> **Confirm prod's actual version before any prod apply.** `ci_terraform` only plans staging, and this config is shared across both workspaces via `local.environment`. 13.23 is verified for staging from the plan above; if prod sits on a different minor, this pin becomes an *upgrade* there rather than a no-op. Worth a quick look at the `echo-server-prod` workspace or the RDS console.

### Merge order

Land this before #386. #386 makes `auto_deploy` work end to end, including the staging `terraform apply` that had never been reached — so with this merged first, that first working apply has nothing to roll back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
